### PR TITLE
fix data too long for column data

### DIFF
--- a/apps/statestores/priv/my_sql/migrations/20220521162410_create_events_table.exs
+++ b/apps/statestores/priv/my_sql/migrations/20220521162410_create_events_table.exs
@@ -1,7 +1,7 @@
 defmodule Statestores.Adapters.MySQL.Migrations.CreateEventsTable do
   use Ecto.Migration
 
-  def change do
+  def up do
     create table(:events) do
       add :system, :string
       add :actor, :string
@@ -12,6 +12,14 @@ defmodule Statestores.Adapters.MySQL.Migrations.CreateEventsTable do
       timestamps()
     end
 
+    execute """
+    ALTER TABLE events MODIFY data LONGBLOB;
+    """
+
     create unique_index(:events, :actor)
+  end
+
+  def down do
+    drop table(:events)
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/eigr/spawn/issues/26

--- 

Maybe LONGBLOB is overkill here, but I'm not sure how and if does it affect too much of performance

```
LONGBLOB stores 4GB
MEDIUMBLOB stores 16mb
BLOB (:binary default) stores only 64kb
```