### PR TITLE
Avoid unnecessary trips to the Registry

### DIFF
--- a/apps/actors/lib/actors.ex
+++ b/apps/actors/lib/actors.ex
@@ -50,10 +50,10 @@ defmodule Actors do
 
   def get_state(system_name, actor_name) do
     case Spawn.Cluster.Node.Registry.lookup(Actors.Actor.Entity, actor_name) do
-      [{pid, nil}] ->
-        Logger.debug("Lookup Actor #{actor_name}. PID: #{inspect(pid)}")
+      [{actor_ref, nil}] ->
+        Logger.debug("Lookup Actor #{actor_name}. PID: #{inspect(actor_ref)}")
         # This return {:ok, response_body}
-        ActorEntity.get_state(actor_name)
+        ActorEntity.get_state(actor_ref)
 
       _ ->
         with {:ok, %{node: node, actor: actor}} <-
@@ -99,10 +99,10 @@ defmodule Actors do
          request
        ) do
     case Spawn.Cluster.Node.Registry.lookup(Actors.Actor.Entity, actor_name) do
-      [{pid, nil}] ->
-        Logger.debug("Lookup Actor #{actor_name}. PID: #{inspect(pid)}")
+      [{actor_ref, nil}] ->
+        Logger.debug("Lookup Actor #{actor_name}. ActorRef PID: #{inspect(actor_ref)}")
         # This return {:ok, response_body}
-        ActorEntity.invoke(actor_name, request)
+        ActorEntity.invoke(actor_ref, request)
 
       _ ->
         with {:ok, %{node: node, actor: _registered_actor}} <-
@@ -138,10 +138,10 @@ defmodule Actors do
          request
        ) do
     case Spawn.Cluster.Node.Registry.lookup(Actors.Actor.Entity, actor_name) do
-      [{pid, nil}] ->
-        Logger.debug("Lookup Actor #{actor_name}. PID: #{inspect(pid)}")
+      [{actor_ref, nil}] ->
+        Logger.debug("Lookup Actor #{actor_name}. ActorRef PID: #{inspect(actor_ref)}")
         # This return {:ok, response_body}
-        ActorEntity.invoke(actor_name, request)
+        ActorEntity.invoke(actor_ref, request)
 
       _ ->
         with {:ok, %{node: node, actor: _registered_actor}} <-
@@ -172,9 +172,9 @@ defmodule Actors do
 
   def try_reactivate_actor(%ActorSystem{} = system, %Actor{name: name} = actor) do
     case ActorEntitySupervisor.lookup_or_create_actor(system, actor) do
-      {:ok, pid} ->
-        Logger.debug("Actor #{name} reactivated. PID: #{inspect(pid)}")
-        {:ok, pid}
+      {:ok, actor_ref} ->
+        Logger.debug("Actor #{name} reactivated. ActorRef PID: #{inspect(actor_ref)}")
+        {:ok, actor_ref}
 
       reason ->
         Logger.error("Failed to reactivate actor #{name}: #{inspect(reason)}")
@@ -185,9 +185,9 @@ defmodule Actors do
   # To lookup all actors
   def try_reactivate_actor(nil, %Actor{name: name} = actor) do
     case ActorEntitySupervisor.lookup_or_create_actor(nil, actor) do
-      {:ok, pid} ->
-        Logger.debug("Actor #{name} reactivated. PID: #{inspect(pid)}")
-        {:ok, pid}
+      {:ok, actor_ref} ->
+        Logger.debug("Actor #{name} reactivated. ActorRef PID: #{inspect(actor_ref)}")
+        {:ok, actor_ref}
 
       reason ->
         Logger.error("Failed to reactivate actor #{name}: #{inspect(reason)}")

--- a/apps/actors/lib/actors/actor/entity.ex
+++ b/apps/actors/lib/actors/actor/entity.ex
@@ -442,16 +442,31 @@ defmodule Actors.Actor.Entity do
     GenServer.start(__MODULE__, state, name: via(name))
   end
 
-  def get_state(name) do
-    GenServer.call(via(name), :get_state, 20_000)
+  @spec get_state(any) :: any
+  def get_state(ref) when is_pid(ref) do
+    GenServer.call(ref, :get_state, 20_000)
   end
 
-  def invoke(name, request) do
-    GenServer.call(via(name), {:invocation_request, request}, 30_000)
+  def get_state(ref) do
+    GenServer.call(via(ref), :get_state, 20_000)
   end
 
-  def invoke_async(name, request) do
-    GenServer.cast(via(name), {:invocation_request, :async, request})
+  @spec invoke(any, any) :: any
+  def invoke(ref, request) when is_pid(ref) do
+    GenServer.call(ref, {:invocation_request, request}, 30_000)
+  end
+
+  def invoke(ref, request) do
+    GenServer.call(via(ref), {:invocation_request, request}, 30_000)
+  end
+
+  @spec invoke_async(any, any) :: :ok
+  def invoke_async(ref, request) when is_pid(ref) do
+    GenServer.cast(ref, {:invocation_request, :async, request})
+  end
+
+  def invoke_async(ref, request) do
+    GenServer.cast(via(ref), {:invocation_request, :async, request})
   end
 
   defp get_timeout_factor(factor_range) when is_number(factor_range),


### PR DESCRIPTION
Following the internal discussion between @eliasdarruda and I, we decided to add a contingency for cases where the Actor already exists and we already have the pid to avoid having to go to the Registry again when making the call to the Actor