### PR TITLE
Simplifies actor lookup logic

### DIFF
--- a/apps/actors/lib/actors.ex
+++ b/apps/actors/lib/actors.ex
@@ -70,7 +70,7 @@ defmodule Actors do
 
   defp do_lookup_action(system_name, actor_name, system, action_fun) do
     case Spawn.Cluster.Node.Registry.lookup(Actors.Actor.Entity, actor_name) do
-      [{actor_ref, nil}] ->
+      [{actor_ref, _}] ->
         Logger.debug("Lookup Actor #{actor_name}. PID: #{inspect(actor_ref)}")
 
         action_fun.(actor_ref)

--- a/apps/actors/lib/actors/actor/entity.ex
+++ b/apps/actors/lib/actors/actor/entity.ex
@@ -442,7 +442,7 @@ defmodule Actors.Actor.Entity do
     GenServer.start(__MODULE__, state, name: via(name))
   end
 
-  @spec get_state(any) :: any
+  @spec get_state(any) :: {:error, term()} | {:ok, term()}
   def get_state(ref) when is_pid(ref) do
     GenServer.call(ref, :get_state, 20_000)
   end

--- a/apps/protos/lib/actors/actor/actor.pb.ex
+++ b/apps/protos/lib/actors/actor/actor.pb.ex
@@ -56,9 +56,10 @@ defmodule Eigr.Functions.Protocol.Actors.Registry.ActorsEntry do
     }
   end
 
-  field :key, 1, type: :string
-  field :value, 2, type: Eigr.Functions.Protocol.Actors.Actor
+  field(:key, 1, type: :string)
+  field(:value, 2, type: Eigr.Functions.Protocol.Actors.Actor)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.Registry do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -146,11 +147,13 @@ defmodule Eigr.Functions.Protocol.Actors.Registry do
     }
   end
 
-  field :actors, 1,
+  field(:actors, 1,
     repeated: true,
     type: Eigr.Functions.Protocol.Actors.Registry.ActorsEntry,
     map: true
+  )
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorSystem do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -201,9 +204,10 @@ defmodule Eigr.Functions.Protocol.Actors.ActorSystem do
     }
   end
 
-  field :name, 1, type: :string
-  field :registry, 2, type: Eigr.Functions.Protocol.Actors.Registry
+  field(:name, 1, type: :string)
+  field(:registry, 2, type: Eigr.Functions.Protocol.Actors.Registry)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -246,10 +250,11 @@ defmodule Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy do
     }
   end
 
-  oneof :strategy, 0
+  oneof(:strategy, 0)
 
-  field :timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0
+  field(:timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -292,10 +297,11 @@ defmodule Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy do
     }
   end
 
-  oneof :strategy, 0
+  oneof(:strategy, 0)
 
-  field :timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0
+  field(:timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.TimeoutStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -332,8 +338,9 @@ defmodule Eigr.Functions.Protocol.Actors.TimeoutStrategy do
     }
   end
 
-  field :timeout, 1, type: :int64
+  field(:timeout, 1, type: :int64)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorState.TagsEntry do
   @moduledoc false
   use Protobuf, map: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -392,9 +399,10 @@ defmodule Eigr.Functions.Protocol.Actors.ActorState.TagsEntry do
     }
   end
 
-  field :key, 1, type: :string
-  field :value, 2, type: :string
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorState do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -496,13 +504,15 @@ defmodule Eigr.Functions.Protocol.Actors.ActorState do
     }
   end
 
-  field :tags, 1,
+  field(:tags, 1,
     repeated: true,
     type: Eigr.Functions.Protocol.Actors.ActorState.TagsEntry,
     map: true
+  )
 
-  field :state, 2, type: Google.Protobuf.Any
+  field(:state, 2, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.Actor do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -595,15 +605,17 @@ defmodule Eigr.Functions.Protocol.Actors.Actor do
     }
   end
 
-  field :name, 1, type: :string
-  field :persistent, 2, type: :bool
-  field :state, 3, type: Eigr.Functions.Protocol.Actors.ActorState
+  field(:name, 1, type: :string)
+  field(:persistent, 2, type: :bool)
+  field(:state, 3, type: Eigr.Functions.Protocol.Actors.ActorState)
 
-  field :snapshot_strategy, 4,
+  field(:snapshot_strategy, 4,
     type: Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy,
     json_name: "snapshotStrategy"
+  )
 
-  field :deactivate_strategy, 5,
+  field(:deactivate_strategy, 5,
     type: Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy,
     json_name: "deactivateStrategy"
+  )
 end

--- a/apps/protos/lib/actors/actor/protocol.pb.ex
+++ b/apps/protos/lib/actors/actor/protocol.pb.ex
@@ -39,11 +39,12 @@ defmodule Eigr.Functions.Protocol.Status do
     }
   end
 
-  field :UNKNOWN, 0
-  field :OK, 1
-  field :ACTOR_NOT_FOUND, 2
-  field :ERROR, 3
+  field(:UNKNOWN, 0)
+  field(:OK, 1)
+  field(:ACTOR_NOT_FOUND, 2)
+  field(:ERROR, 3)
 end
+
 defmodule Eigr.Functions.Protocol.RegistrationRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -94,12 +95,14 @@ defmodule Eigr.Functions.Protocol.RegistrationRequest do
     }
   end
 
-  field :service_info, 1, type: Eigr.Functions.Protocol.ServiceInfo, json_name: "serviceInfo"
+  field(:service_info, 1, type: Eigr.Functions.Protocol.ServiceInfo, json_name: "serviceInfo")
 
-  field :actor_system, 2,
+  field(:actor_system, 2,
     type: Eigr.Functions.Protocol.Actors.ActorSystem,
     json_name: "actorSystem"
+  )
 end
+
 defmodule Eigr.Functions.Protocol.ServiceInfo do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -220,14 +223,15 @@ defmodule Eigr.Functions.Protocol.ServiceInfo do
     }
   end
 
-  field :service_name, 1, type: :string, json_name: "serviceName"
-  field :service_version, 2, type: :string, json_name: "serviceVersion"
-  field :service_runtime, 3, type: :string, json_name: "serviceRuntime"
-  field :support_library_name, 4, type: :string, json_name: "supportLibraryName"
-  field :support_library_version, 5, type: :string, json_name: "supportLibraryVersion"
-  field :protocol_major_version, 6, type: :int32, json_name: "protocolMajorVersion"
-  field :protocol_minor_version, 7, type: :int32, json_name: "protocolMinorVersion"
+  field(:service_name, 1, type: :string, json_name: "serviceName")
+  field(:service_version, 2, type: :string, json_name: "serviceVersion")
+  field(:service_runtime, 3, type: :string, json_name: "serviceRuntime")
+  field(:support_library_name, 4, type: :string, json_name: "supportLibraryName")
+  field(:support_library_version, 5, type: :string, json_name: "supportLibraryVersion")
+  field(:protocol_major_version, 6, type: :int32, json_name: "protocolMajorVersion")
+  field(:protocol_minor_version, 7, type: :int32, json_name: "protocolMinorVersion")
 end
+
 defmodule Eigr.Functions.Protocol.ProxyInfo do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -306,11 +310,12 @@ defmodule Eigr.Functions.Protocol.ProxyInfo do
     }
   end
 
-  field :protocol_major_version, 1, type: :int32, json_name: "protocolMajorVersion"
-  field :protocol_minor_version, 2, type: :int32, json_name: "protocolMinorVersion"
-  field :proxy_name, 3, type: :string, json_name: "proxyName"
-  field :proxy_version, 4, type: :string, json_name: "proxyVersion"
+  field(:protocol_major_version, 1, type: :int32, json_name: "protocolMajorVersion")
+  field(:protocol_minor_version, 2, type: :int32, json_name: "protocolMinorVersion")
+  field(:proxy_name, 3, type: :string, json_name: "proxyName")
+  field(:proxy_version, 4, type: :string, json_name: "proxyVersion")
 end
+
 defmodule Eigr.Functions.Protocol.RegistrationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -361,9 +366,10 @@ defmodule Eigr.Functions.Protocol.RegistrationResponse do
     }
   end
 
-  field :status, 1, type: Eigr.Functions.Protocol.RequestStatus
-  field :proxy_info, 2, type: Eigr.Functions.Protocol.ProxyInfo, json_name: "proxyInfo"
+  field(:status, 1, type: Eigr.Functions.Protocol.RequestStatus)
+  field(:proxy_info, 2, type: Eigr.Functions.Protocol.ProxyInfo, json_name: "proxyInfo")
 end
+
 defmodule Eigr.Functions.Protocol.Context do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -400,8 +406,9 @@ defmodule Eigr.Functions.Protocol.Context do
     }
   end
 
-  field :state, 1, type: Google.Protobuf.Any
+  field(:state, 1, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.InvocationRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -494,12 +501,13 @@ defmodule Eigr.Functions.Protocol.InvocationRequest do
     }
   end
 
-  field :system, 1, type: Eigr.Functions.Protocol.Actors.ActorSystem
-  field :actor, 2, type: Eigr.Functions.Protocol.Actors.Actor
-  field :command_name, 3, type: :string, json_name: "commandName"
-  field :value, 4, type: Google.Protobuf.Any
-  field :async, 5, type: :bool
+  field(:system, 1, type: Eigr.Functions.Protocol.Actors.ActorSystem)
+  field(:actor, 2, type: Eigr.Functions.Protocol.Actors.Actor)
+  field(:command_name, 3, type: :string, json_name: "commandName")
+  field(:value, 4, type: Google.Protobuf.Any)
+  field(:async, 5, type: :bool)
 end
+
 defmodule Eigr.Functions.Protocol.ActorInvocation do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -592,12 +600,13 @@ defmodule Eigr.Functions.Protocol.ActorInvocation do
     }
   end
 
-  field :actor_name, 1, type: :string, json_name: "actorName"
-  field :actor_system, 2, type: :string, json_name: "actorSystem"
-  field :command_name, 3, type: :string, json_name: "commandName"
-  field :current_context, 4, type: Eigr.Functions.Protocol.Context, json_name: "currentContext"
-  field :value, 5, type: Google.Protobuf.Any
+  field(:actor_name, 1, type: :string, json_name: "actorName")
+  field(:actor_system, 2, type: :string, json_name: "actorSystem")
+  field(:command_name, 3, type: :string, json_name: "commandName")
+  field(:current_context, 4, type: Eigr.Functions.Protocol.Context, json_name: "currentContext")
+  field(:value, 5, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.ActorInvocationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -676,11 +685,12 @@ defmodule Eigr.Functions.Protocol.ActorInvocationResponse do
     }
   end
 
-  field :actor_name, 1, type: :string, json_name: "actorName"
-  field :actor_system, 2, type: :string, json_name: "actorSystem"
-  field :updated_context, 3, type: Eigr.Functions.Protocol.Context, json_name: "updatedContext"
-  field :value, 4, type: Google.Protobuf.Any
+  field(:actor_name, 1, type: :string, json_name: "actorName")
+  field(:actor_system, 2, type: :string, json_name: "actorSystem")
+  field(:updated_context, 3, type: Eigr.Functions.Protocol.Context, json_name: "updatedContext")
+  field(:value, 4, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.InvocationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -759,11 +769,12 @@ defmodule Eigr.Functions.Protocol.InvocationResponse do
     }
   end
 
-  field :status, 1, type: Eigr.Functions.Protocol.RequestStatus
-  field :system, 2, type: Eigr.Functions.Protocol.Actors.ActorSystem
-  field :actor, 3, type: Eigr.Functions.Protocol.Actors.Actor
-  field :value, 4, type: Google.Protobuf.Any
+  field(:status, 1, type: Eigr.Functions.Protocol.RequestStatus)
+  field(:system, 2, type: Eigr.Functions.Protocol.Actors.ActorSystem)
+  field(:actor, 3, type: Eigr.Functions.Protocol.Actors.Actor)
+  field(:value, 4, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.RequestStatus do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -814,6 +825,6 @@ defmodule Eigr.Functions.Protocol.RequestStatus do
     }
   end
 
-  field :status, 1, type: Eigr.Functions.Protocol.Status, enum: true
-  field :message, 2, type: :string
+  field(:status, 1, type: Eigr.Functions.Protocol.Status, enum: true)
+  field(:message, 2, type: :string)
 end

--- a/apps/protos/lib/cloudevents/spec.pb.ex
+++ b/apps/protos/lib/cloudevents/spec.pb.ex
@@ -56,9 +56,10 @@ defmodule Io.Cloudevents.V1.CloudEvent.AttributesEntry do
     }
   end
 
-  field :key, 1, type: :string
-  field :value, 2, type: Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue
+  field(:key, 1, type: :string)
+  field(:value, 2, type: Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue)
 end
+
 defmodule Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -181,16 +182,17 @@ defmodule Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue do
     }
   end
 
-  oneof :attr, 0
+  oneof(:attr, 0)
 
-  field :ce_boolean, 1, type: :bool, json_name: "ceBoolean", oneof: 0
-  field :ce_integer, 2, type: :int32, json_name: "ceInteger", oneof: 0
-  field :ce_string, 3, type: :string, json_name: "ceString", oneof: 0
-  field :ce_bytes, 4, type: :bytes, json_name: "ceBytes", oneof: 0
-  field :ce_uri, 5, type: :string, json_name: "ceUri", oneof: 0
-  field :ce_uri_ref, 6, type: :string, json_name: "ceUriRef", oneof: 0
-  field :ce_timestamp, 7, type: Google.Protobuf.Timestamp, json_name: "ceTimestamp", oneof: 0
+  field(:ce_boolean, 1, type: :bool, json_name: "ceBoolean", oneof: 0)
+  field(:ce_integer, 2, type: :int32, json_name: "ceInteger", oneof: 0)
+  field(:ce_string, 3, type: :string, json_name: "ceString", oneof: 0)
+  field(:ce_bytes, 4, type: :bytes, json_name: "ceBytes", oneof: 0)
+  field(:ce_uri, 5, type: :string, json_name: "ceUri", oneof: 0)
+  field(:ce_uri_ref, 6, type: :string, json_name: "ceUriRef", oneof: 0)
+  field(:ce_timestamp, 7, type: Google.Protobuf.Timestamp, json_name: "ceTimestamp", oneof: 0)
 end
+
 defmodule Io.Cloudevents.V1.CloudEvent do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -496,19 +498,20 @@ defmodule Io.Cloudevents.V1.CloudEvent do
     }
   end
 
-  oneof :data, 0
+  oneof(:data, 0)
 
-  field :id, 1, type: :string
-  field :source, 2, type: :string
-  field :spec_version, 3, type: :string, json_name: "specVersion"
-  field :type, 4, type: :string
+  field(:id, 1, type: :string)
+  field(:source, 2, type: :string)
+  field(:spec_version, 3, type: :string, json_name: "specVersion")
+  field(:type, 4, type: :string)
 
-  field :attributes, 5,
+  field(:attributes, 5,
     repeated: true,
     type: Io.Cloudevents.V1.CloudEvent.AttributesEntry,
     map: true
+  )
 
-  field :binary_data, 6, type: :bytes, json_name: "binaryData", oneof: 0
-  field :text_data, 7, type: :string, json_name: "textData", oneof: 0
-  field :proto_data, 8, type: Google.Protobuf.Any, json_name: "protoData", oneof: 0
+  field(:binary_data, 6, type: :bytes, json_name: "binaryData", oneof: 0)
+  field(:text_data, 7, type: :string, json_name: "textData", oneof: 0)
+  field(:proto_data, 8, type: Google.Protobuf.Any, json_name: "protoData", oneof: 0)
 end

--- a/apps/protos/lib/google/protobuf/any.pb.ex
+++ b/apps/protos/lib/google/protobuf/any.pb.ex
@@ -48,6 +48,6 @@ defmodule Google.Protobuf.Any do
     }
   end
 
-  field :type_url, 1, type: :string, json_name: "typeUrl"
-  field :value, 2, type: :bytes
+  field(:type_url, 1, type: :string, json_name: "typeUrl")
+  field(:value, 2, type: :bytes)
 end


### PR DESCRIPTION
This is meant to:

- Simplify and centralize and the actor lookup logic (remove duplicated code)
- Use of :erpc call instead of Node.spawn to ensure we have the actor we are trying to reference
- Avoid Process.sleep call
- Avoid hard failing in case of Net split (and other scenarios) in case of not finding the Node to spawn the try_reactivate_actor function thus throwing the process not started exception afterwards
- Returns a expected :erpc timeout
- fixes endpoint for async invokes
- mix format