### PR TITLE
fix node spawn without timeout failing CI

### DIFF
--- a/apps/spawn/test/support/node_helper.ex
+++ b/apps/spawn/test/support/node_helper.ex
@@ -12,8 +12,7 @@ defmodule Spawn.NodeHelper do
     :erl_boot_server.start([])
     allow_boot to_charlist("127.0.0.1")
 
-    Task.async(fn -> spawn_node(:"#{node_name}@127.0.0.1") end)
-    |> Task.await(30_000)
+    spawn_node(:"#{node_name}@127.0.0.1")
   end
 
   def rpc(node, module, function, args) do


### PR DESCRIPTION
This is using a unecessary Task timeout, in some CI environments this is slower than 30s, i don't think timeout here is needed