### PR TITLE
Spawning Actors on the fly

### DIFF
--- a/apps/actors/lib/actors.ex
+++ b/apps/actors/lib/actors.ex
@@ -16,7 +16,10 @@ defmodule Actors do
     ProxyInfo,
     RegistrationRequest,
     RegistrationResponse,
-    ServiceInfo
+    RequestStatus,
+    ServiceInfo,
+    SpawnRequest,
+    SpawnResponse
   }
 
   @activate_actors_min_demand 0
@@ -47,6 +50,23 @@ defmodule Actors do
       )
 
     {:ok, RegistrationResponse.new(proxy_info: proxy_info)}
+  end
+
+  def spawn_actor(
+        %SpawnRequest{
+          actor_system:
+            %ActorSystem{name: _name, registry: %Registry{actors: actors} = _registry} =
+              actor_system
+        } = _registration
+      ) do
+    ActorRegistry.register(actors)
+
+    spawn(fn ->
+      create_actors(actor_system, actors)
+    end)
+
+    status = RequestStatus.new(status: :OK, message: "Accepted")
+    {:ok, SpawnResponse.new(status: SpawnResponse.new(status: status))}
   end
 
   def get_state(system_name, actor_name) do

--- a/apps/actors/lib/actors/actor/entity.ex
+++ b/apps/actors/lib/actors/actor/entity.ex
@@ -223,34 +223,34 @@ defmodule Actors.Actor.Entity do
     case Actors.Node.Client.invoke_host_actor(payload) do
       {:ok, %Tesla.Env{body: ""}} ->
         Logger.error("User Function Actor response Invocation body is empty")
-        {:error, :no_content}
+        {:error, :no_content, :hibernate}
 
       {:ok, %Tesla.Env{body: nil}} ->
         Logger.error("User Function Actor response Invocation body is nil")
-        {:error, :no_content}
+        {:error, :no_content, :hibernate}
 
       {:ok, %Tesla.Env{body: body}} ->
         with %ActorInvocationResponse{
                updated_context: %Context{} = user_ctx
              } = resp <- ActorInvocationResponse.decode(body) do
-          {:reply, {:ok, resp}, update_state(state, user_ctx)}
+          {:reply, {:ok, resp}, update_state(state, user_ctx), :hibernate}
         else
           error ->
             Logger.error("Error on parse response #{inspect(error)}")
-            {:reply, {:error, :invalid_content}, state}
+            {:reply, {:error, :invalid_content}, state, :hibernate}
         end
 
       {:error, timeout} ->
         Logger.error("User Function Actor Invocation Timeout Error")
-        {:reply, {:error, timeout}, state}
+        {:reply, {:error, timeout}, state, :hibernate}
 
       {:error, reason} ->
         Logger.error("User Function Actor Invocation Unknown Error: #{inspect(reason)}")
-        {:reply, {:error, reason}, state}
+        {:reply, {:error, reason}, state, :hibernate}
 
       error ->
         Logger.error("User Function Actor Invocation Unknown Error")
-        {:reply, {:error, error}, state}
+        {:reply, {:error, error}, state, :hibernate}
     end
   end
 
@@ -281,34 +281,34 @@ defmodule Actors.Actor.Entity do
     case Actors.Node.Client.invoke_host_actor(payload) do
       {:ok, %Tesla.Env{body: ""}} ->
         Logger.error("User Function Actor response Invocation body is empty")
-        {:error, :no_content}
+        {:error, :no_content, :hibernate}
 
       {:ok, %Tesla.Env{body: nil}} ->
         Logger.error("User Function Actor response Invocation body is nil")
-        {:error, :no_content}
+        {:error, :no_content, :hibernate}
 
       {:ok, %Tesla.Env{body: body}} ->
         with %ActorInvocationResponse{
                updated_context: %Context{} = user_ctx
              } = resp <- ActorInvocationResponse.decode(body) do
-          {:reply, {:ok, resp}, update_state(state, user_ctx)}
+          {:reply, {:ok, resp}, update_state(state, user_ctx), :hibernate}
         else
           error ->
             Logger.error("Error on parse response #{inspect(error)}")
-            {:reply, {:error, :invalid_content}, state}
+            {:reply, {:error, :invalid_content}, state, :hibernate}
         end
 
       {:error, timeout} ->
         Logger.error("User Function Actor Invocation Timeout Error")
-        {:reply, {:error, timeout}, state}
+        {:reply, {:error, timeout}, state, :hibernate}
 
       {:error, reason} ->
         Logger.error("User Function Actor Invocation Unknown Error: #{inspect(reason)}")
-        {:reply, {:error, reason}, state}
+        {:reply, {:error, reason}, state, :hibernate}
 
       error ->
         Logger.error("User Function Actor Invocation Unknown Error")
-        {:reply, {:error, error}, state}
+        {:reply, {:error, error}, state, :hibernate}
     end
   end
 

--- a/apps/actors/lib/actors/actor/entity.ex
+++ b/apps/actors/lib/actors/actor/entity.ex
@@ -172,6 +172,10 @@ defmodule Actors.Actor.Entity do
       {:not_found, %{}} ->
         Logger.debug("Not found initial state on statestore for Actor #{name}.")
         {:noreply, state, :hibernate}
+
+      error ->
+        Logger.error("Error on load state for Actor #{name}. Error: #{inspect(error)}")
+        {:noreply, state, :hibernate}
     end
   end
 

--- a/apps/spawn/lib/protos/actors/actor/actor.pb.ex
+++ b/apps/spawn/lib/protos/actors/actor/actor.pb.ex
@@ -56,10 +56,9 @@ defmodule Eigr.Functions.Protocol.Actors.Registry.ActorsEntry do
     }
   end
 
-  field(:key, 1, type: :string)
-  field(:value, 2, type: Eigr.Functions.Protocol.Actors.Actor)
+  field :key, 1, type: :string
+  field :value, 2, type: Eigr.Functions.Protocol.Actors.Actor
 end
-
 defmodule Eigr.Functions.Protocol.Actors.Registry do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -147,13 +146,11 @@ defmodule Eigr.Functions.Protocol.Actors.Registry do
     }
   end
 
-  field(:actors, 1,
+  field :actors, 1,
     repeated: true,
     type: Eigr.Functions.Protocol.Actors.Registry.ActorsEntry,
     map: true
-  )
 end
-
 defmodule Eigr.Functions.Protocol.Actors.ActorSystem do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -204,10 +201,9 @@ defmodule Eigr.Functions.Protocol.Actors.ActorSystem do
     }
   end
 
-  field(:name, 1, type: :string)
-  field(:registry, 2, type: Eigr.Functions.Protocol.Actors.Registry)
+  field :name, 1, type: :string
+  field :registry, 2, type: Eigr.Functions.Protocol.Actors.Registry
 end
-
 defmodule Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -250,11 +246,10 @@ defmodule Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy do
     }
   end
 
-  oneof(:strategy, 0)
+  oneof :strategy, 0
 
-  field(:timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0)
+  field :timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0
 end
-
 defmodule Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -297,11 +292,10 @@ defmodule Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy do
     }
   end
 
-  oneof(:strategy, 0)
+  oneof :strategy, 0
 
-  field(:timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0)
+  field :timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0
 end
-
 defmodule Eigr.Functions.Protocol.Actors.TimeoutStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -338,9 +332,8 @@ defmodule Eigr.Functions.Protocol.Actors.TimeoutStrategy do
     }
   end
 
-  field(:timeout, 1, type: :int64)
+  field :timeout, 1, type: :int64
 end
-
 defmodule Eigr.Functions.Protocol.Actors.ActorState.TagsEntry do
   @moduledoc false
   use Protobuf, map: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -399,10 +392,9 @@ defmodule Eigr.Functions.Protocol.Actors.ActorState.TagsEntry do
     }
   end
 
-  field(:key, 1, type: :string)
-  field(:value, 2, type: :string)
+  field :key, 1, type: :string
+  field :value, 2, type: :string
 end
-
 defmodule Eigr.Functions.Protocol.Actors.ActorState do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -504,15 +496,13 @@ defmodule Eigr.Functions.Protocol.Actors.ActorState do
     }
   end
 
-  field(:tags, 1,
+  field :tags, 1,
     repeated: true,
     type: Eigr.Functions.Protocol.Actors.ActorState.TagsEntry,
     map: true
-  )
 
-  field(:state, 2, type: Google.Protobuf.Any)
+  field :state, 2, type: Google.Protobuf.Any
 end
-
 defmodule Eigr.Functions.Protocol.Actors.Actor do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -605,17 +595,15 @@ defmodule Eigr.Functions.Protocol.Actors.Actor do
     }
   end
 
-  field(:name, 1, type: :string)
-  field(:persistent, 2, type: :bool)
-  field(:state, 3, type: Eigr.Functions.Protocol.Actors.ActorState)
+  field :name, 1, type: :string
+  field :persistent, 2, type: :bool
+  field :state, 3, type: Eigr.Functions.Protocol.Actors.ActorState
 
-  field(:snapshot_strategy, 4,
+  field :snapshot_strategy, 4,
     type: Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy,
     json_name: "snapshotStrategy"
-  )
 
-  field(:deactivate_strategy, 5,
+  field :deactivate_strategy, 5,
     type: Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy,
     json_name: "deactivateStrategy"
-  )
 end

--- a/apps/spawn/lib/protos/actors/actor/protocol.pb.ex
+++ b/apps/spawn/lib/protos/actors/actor/protocol.pb.ex
@@ -39,12 +39,89 @@ defmodule Eigr.Functions.Protocol.Status do
     }
   end
 
-  field(:UNKNOWN, 0)
-  field(:OK, 1)
-  field(:ACTOR_NOT_FOUND, 2)
-  field(:ERROR, 3)
+  field :UNKNOWN, 0
+  field :OK, 1
+  field :ACTOR_NOT_FOUND, 2
+  field :ERROR, 3
 end
+defmodule Eigr.Functions.Protocol.SpawnRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
 
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      __unknown_fields__: [],
+      enum_type: [],
+      extension: [],
+      extension_range: [],
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          __unknown_fields__: [],
+          default_value: nil,
+          extendee: nil,
+          json_name: "actorSystem",
+          label: :LABEL_OPTIONAL,
+          name: "actor_system",
+          number: 2,
+          oneof_index: nil,
+          options: nil,
+          proto3_optional: nil,
+          type: :TYPE_MESSAGE,
+          type_name: ".eigr.functions.protocol.actors.ActorSystem"
+        }
+      ],
+      name: "SpawnRequest",
+      nested_type: [],
+      oneof_decl: [],
+      options: nil,
+      reserved_name: [],
+      reserved_range: []
+    }
+  end
+
+  field :actor_system, 2,
+    type: Eigr.Functions.Protocol.Actors.ActorSystem,
+    json_name: "actorSystem"
+end
+defmodule Eigr.Functions.Protocol.SpawnResponse do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      __unknown_fields__: [],
+      enum_type: [],
+      extension: [],
+      extension_range: [],
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          __unknown_fields__: [],
+          default_value: nil,
+          extendee: nil,
+          json_name: "status",
+          label: :LABEL_OPTIONAL,
+          name: "status",
+          number: 1,
+          oneof_index: nil,
+          options: nil,
+          proto3_optional: nil,
+          type: :TYPE_MESSAGE,
+          type_name: ".eigr.functions.protocol.RequestStatus"
+        }
+      ],
+      name: "SpawnResponse",
+      nested_type: [],
+      oneof_decl: [],
+      options: nil,
+      reserved_name: [],
+      reserved_range: []
+    }
+  end
+
+  field :status, 1, type: Eigr.Functions.Protocol.RequestStatus
+end
 defmodule Eigr.Functions.Protocol.RegistrationRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -95,14 +172,12 @@ defmodule Eigr.Functions.Protocol.RegistrationRequest do
     }
   end
 
-  field(:service_info, 1, type: Eigr.Functions.Protocol.ServiceInfo, json_name: "serviceInfo")
+  field :service_info, 1, type: Eigr.Functions.Protocol.ServiceInfo, json_name: "serviceInfo"
 
-  field(:actor_system, 2,
+  field :actor_system, 2,
     type: Eigr.Functions.Protocol.Actors.ActorSystem,
     json_name: "actorSystem"
-  )
 end
-
 defmodule Eigr.Functions.Protocol.ServiceInfo do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -223,15 +298,14 @@ defmodule Eigr.Functions.Protocol.ServiceInfo do
     }
   end
 
-  field(:service_name, 1, type: :string, json_name: "serviceName")
-  field(:service_version, 2, type: :string, json_name: "serviceVersion")
-  field(:service_runtime, 3, type: :string, json_name: "serviceRuntime")
-  field(:support_library_name, 4, type: :string, json_name: "supportLibraryName")
-  field(:support_library_version, 5, type: :string, json_name: "supportLibraryVersion")
-  field(:protocol_major_version, 6, type: :int32, json_name: "protocolMajorVersion")
-  field(:protocol_minor_version, 7, type: :int32, json_name: "protocolMinorVersion")
+  field :service_name, 1, type: :string, json_name: "serviceName"
+  field :service_version, 2, type: :string, json_name: "serviceVersion"
+  field :service_runtime, 3, type: :string, json_name: "serviceRuntime"
+  field :support_library_name, 4, type: :string, json_name: "supportLibraryName"
+  field :support_library_version, 5, type: :string, json_name: "supportLibraryVersion"
+  field :protocol_major_version, 6, type: :int32, json_name: "protocolMajorVersion"
+  field :protocol_minor_version, 7, type: :int32, json_name: "protocolMinorVersion"
 end
-
 defmodule Eigr.Functions.Protocol.ProxyInfo do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -310,12 +384,11 @@ defmodule Eigr.Functions.Protocol.ProxyInfo do
     }
   end
 
-  field(:protocol_major_version, 1, type: :int32, json_name: "protocolMajorVersion")
-  field(:protocol_minor_version, 2, type: :int32, json_name: "protocolMinorVersion")
-  field(:proxy_name, 3, type: :string, json_name: "proxyName")
-  field(:proxy_version, 4, type: :string, json_name: "proxyVersion")
+  field :protocol_major_version, 1, type: :int32, json_name: "protocolMajorVersion"
+  field :protocol_minor_version, 2, type: :int32, json_name: "protocolMinorVersion"
+  field :proxy_name, 3, type: :string, json_name: "proxyName"
+  field :proxy_version, 4, type: :string, json_name: "proxyVersion"
 end
-
 defmodule Eigr.Functions.Protocol.RegistrationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -366,10 +439,9 @@ defmodule Eigr.Functions.Protocol.RegistrationResponse do
     }
   end
 
-  field(:status, 1, type: Eigr.Functions.Protocol.RequestStatus)
-  field(:proxy_info, 2, type: Eigr.Functions.Protocol.ProxyInfo, json_name: "proxyInfo")
+  field :status, 1, type: Eigr.Functions.Protocol.RequestStatus
+  field :proxy_info, 2, type: Eigr.Functions.Protocol.ProxyInfo, json_name: "proxyInfo"
 end
-
 defmodule Eigr.Functions.Protocol.Context do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -406,9 +478,8 @@ defmodule Eigr.Functions.Protocol.Context do
     }
   end
 
-  field(:state, 1, type: Google.Protobuf.Any)
+  field :state, 1, type: Google.Protobuf.Any
 end
-
 defmodule Eigr.Functions.Protocol.InvocationRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -501,13 +572,12 @@ defmodule Eigr.Functions.Protocol.InvocationRequest do
     }
   end
 
-  field(:system, 1, type: Eigr.Functions.Protocol.Actors.ActorSystem)
-  field(:actor, 2, type: Eigr.Functions.Protocol.Actors.Actor)
-  field(:command_name, 3, type: :string, json_name: "commandName")
-  field(:value, 4, type: Google.Protobuf.Any)
-  field(:async, 5, type: :bool)
+  field :system, 1, type: Eigr.Functions.Protocol.Actors.ActorSystem
+  field :actor, 2, type: Eigr.Functions.Protocol.Actors.Actor
+  field :command_name, 3, type: :string, json_name: "commandName"
+  field :value, 4, type: Google.Protobuf.Any
+  field :async, 5, type: :bool
 end
-
 defmodule Eigr.Functions.Protocol.ActorInvocation do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -600,13 +670,12 @@ defmodule Eigr.Functions.Protocol.ActorInvocation do
     }
   end
 
-  field(:actor_name, 1, type: :string, json_name: "actorName")
-  field(:actor_system, 2, type: :string, json_name: "actorSystem")
-  field(:command_name, 3, type: :string, json_name: "commandName")
-  field(:current_context, 4, type: Eigr.Functions.Protocol.Context, json_name: "currentContext")
-  field(:value, 5, type: Google.Protobuf.Any)
+  field :actor_name, 1, type: :string, json_name: "actorName"
+  field :actor_system, 2, type: :string, json_name: "actorSystem"
+  field :command_name, 3, type: :string, json_name: "commandName"
+  field :current_context, 4, type: Eigr.Functions.Protocol.Context, json_name: "currentContext"
+  field :value, 5, type: Google.Protobuf.Any
 end
-
 defmodule Eigr.Functions.Protocol.ActorInvocationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -685,12 +754,11 @@ defmodule Eigr.Functions.Protocol.ActorInvocationResponse do
     }
   end
 
-  field(:actor_name, 1, type: :string, json_name: "actorName")
-  field(:actor_system, 2, type: :string, json_name: "actorSystem")
-  field(:updated_context, 3, type: Eigr.Functions.Protocol.Context, json_name: "updatedContext")
-  field(:value, 4, type: Google.Protobuf.Any)
+  field :actor_name, 1, type: :string, json_name: "actorName"
+  field :actor_system, 2, type: :string, json_name: "actorSystem"
+  field :updated_context, 3, type: Eigr.Functions.Protocol.Context, json_name: "updatedContext"
+  field :value, 4, type: Google.Protobuf.Any
 end
-
 defmodule Eigr.Functions.Protocol.InvocationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -769,12 +837,11 @@ defmodule Eigr.Functions.Protocol.InvocationResponse do
     }
   end
 
-  field(:status, 1, type: Eigr.Functions.Protocol.RequestStatus)
-  field(:system, 2, type: Eigr.Functions.Protocol.Actors.ActorSystem)
-  field(:actor, 3, type: Eigr.Functions.Protocol.Actors.Actor)
-  field(:value, 4, type: Google.Protobuf.Any)
+  field :status, 1, type: Eigr.Functions.Protocol.RequestStatus
+  field :system, 2, type: Eigr.Functions.Protocol.Actors.ActorSystem
+  field :actor, 3, type: Eigr.Functions.Protocol.Actors.Actor
+  field :value, 4, type: Google.Protobuf.Any
 end
-
 defmodule Eigr.Functions.Protocol.RequestStatus do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -825,6 +892,6 @@ defmodule Eigr.Functions.Protocol.RequestStatus do
     }
   end
 
-  field(:status, 1, type: Eigr.Functions.Protocol.Status, enum: true)
-  field(:message, 2, type: :string)
+  field :status, 1, type: Eigr.Functions.Protocol.Status, enum: true
+  field :message, 2, type: :string
 end

--- a/apps/spawn/lib/protos/cloudevents/spec.pb.ex
+++ b/apps/spawn/lib/protos/cloudevents/spec.pb.ex
@@ -56,10 +56,9 @@ defmodule Io.Cloudevents.V1.CloudEvent.AttributesEntry do
     }
   end
 
-  field(:key, 1, type: :string)
-  field(:value, 2, type: Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue)
+  field :key, 1, type: :string
+  field :value, 2, type: Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue
 end
-
 defmodule Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -182,17 +181,16 @@ defmodule Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue do
     }
   end
 
-  oneof(:attr, 0)
+  oneof :attr, 0
 
-  field(:ce_boolean, 1, type: :bool, json_name: "ceBoolean", oneof: 0)
-  field(:ce_integer, 2, type: :int32, json_name: "ceInteger", oneof: 0)
-  field(:ce_string, 3, type: :string, json_name: "ceString", oneof: 0)
-  field(:ce_bytes, 4, type: :bytes, json_name: "ceBytes", oneof: 0)
-  field(:ce_uri, 5, type: :string, json_name: "ceUri", oneof: 0)
-  field(:ce_uri_ref, 6, type: :string, json_name: "ceUriRef", oneof: 0)
-  field(:ce_timestamp, 7, type: Google.Protobuf.Timestamp, json_name: "ceTimestamp", oneof: 0)
+  field :ce_boolean, 1, type: :bool, json_name: "ceBoolean", oneof: 0
+  field :ce_integer, 2, type: :int32, json_name: "ceInteger", oneof: 0
+  field :ce_string, 3, type: :string, json_name: "ceString", oneof: 0
+  field :ce_bytes, 4, type: :bytes, json_name: "ceBytes", oneof: 0
+  field :ce_uri, 5, type: :string, json_name: "ceUri", oneof: 0
+  field :ce_uri_ref, 6, type: :string, json_name: "ceUriRef", oneof: 0
+  field :ce_timestamp, 7, type: Google.Protobuf.Timestamp, json_name: "ceTimestamp", oneof: 0
 end
-
 defmodule Io.Cloudevents.V1.CloudEvent do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -498,20 +496,19 @@ defmodule Io.Cloudevents.V1.CloudEvent do
     }
   end
 
-  oneof(:data, 0)
+  oneof :data, 0
 
-  field(:id, 1, type: :string)
-  field(:source, 2, type: :string)
-  field(:spec_version, 3, type: :string, json_name: "specVersion")
-  field(:type, 4, type: :string)
+  field :id, 1, type: :string
+  field :source, 2, type: :string
+  field :spec_version, 3, type: :string, json_name: "specVersion"
+  field :type, 4, type: :string
 
-  field(:attributes, 5,
+  field :attributes, 5,
     repeated: true,
     type: Io.Cloudevents.V1.CloudEvent.AttributesEntry,
     map: true
-  )
 
-  field(:binary_data, 6, type: :bytes, json_name: "binaryData", oneof: 0)
-  field(:text_data, 7, type: :string, json_name: "textData", oneof: 0)
-  field(:proto_data, 8, type: Google.Protobuf.Any, json_name: "protoData", oneof: 0)
+  field :binary_data, 6, type: :bytes, json_name: "binaryData", oneof: 0
+  field :text_data, 7, type: :string, json_name: "textData", oneof: 0
+  field :proto_data, 8, type: Google.Protobuf.Any, json_name: "protoData", oneof: 0
 end

--- a/apps/spawn/lib/protos/google/protobuf/any.pb.ex
+++ b/apps/spawn/lib/protos/google/protobuf/any.pb.ex
@@ -48,6 +48,6 @@ defmodule Google.Protobuf.Any do
     }
   end
 
-  field(:type_url, 1, type: :string, json_name: "typeUrl")
-  field(:value, 2, type: :bytes)
+  field :type_url, 1, type: :string, json_name: "typeUrl"
+  field :value, 2, type: :bytes
 end

--- a/apps/spawn/priv/protos/eigr/functions/protocol/actors/protocol.proto
+++ b/apps/spawn/priv/protos/eigr/functions/protocol/actors/protocol.proto
@@ -118,6 +118,14 @@ import "google/protobuf/any.proto";
 option java_package = "io.eigr.functions.protocol";
 option go_package = "github.com/eigr/go-support/eigr/protocol;protocol";
 
+message SpawnRequest {
+    eigr.functions.protocol.actors.ActorSystem actor_system = 2;
+}
+
+message SpawnResponse {
+    RequestStatus status = 1;
+}
+
 message RegistrationRequest {
 
     ServiceInfo service_info = 1;

--- a/apps/statestores/lib/statestores/adapters/behaviour.ex
+++ b/apps/statestores/lib/statestores/adapters/behaviour.ex
@@ -52,6 +52,13 @@ defmodule Statestores.Adapters.Behaviour do
             String.to_integer(System.get_env("PROXY_DATABASE_POOL_SIZE", "60"))
           )
 
+        config =
+          Keyword.put(
+            config,
+            :queue_target,
+            String.to_integer(System.get_env("PROXY_DATABASE_QUEUE_TARGET", "10000"))
+          )
+
         {:ok, config}
       end
     end

--- a/apps/statestores/priv/postgres/migrations/20220521162410_create_events_table.exs
+++ b/apps/statestores/priv/postgres/migrations/20220521162410_create_events_table.exs
@@ -1,7 +1,7 @@
 defmodule Statestores.Adapters.Postgres.Migrations.CreateEventsTable do
   use Ecto.Migration
 
-  def change do
+  def up do
     create table(:events) do
       add :system, :string
       add :actor, :string
@@ -13,5 +13,9 @@ defmodule Statestores.Adapters.Postgres.Migrations.CreateEventsTable do
     end
 
     create unique_index(:events, :actor)
+  end
+
+  def down do
+    drop table(:events)
   end
 end


### PR DESCRIPTION
FYD @eliasdarruda @marcellanz @joaomannes @wesleimp

I've added a new feature in the api that allows for the creation of actors on the fly. I will document in another PR to create actors on the fly, just make a POST request to the /system/:name/actors/spawn endpoint and pass the SpawnRequest object in the body of the request.

I already implemented this feature in the SDK for Java and you can take a look at this PR  https://github.com/eigr/spawn-springboot-sdk/pull/4 for an implementation guide.