### PR TITLE
Added default get state methods

### DIFF
--- a/apps/actors/lib/actors/actor/entity.ex
+++ b/apps/actors/lib/actors/actor/entity.ex
@@ -541,11 +541,11 @@ defmodule Actors.Actor.Entity do
       |> case do
         {:ok, %Tesla.Env{body: ""}} ->
           Logger.error("User Function Actor response Invocation body is empty")
-          {:error, :no_content}
+          {:reply, {:error, :no_content}, state}
 
         {:ok, %Tesla.Env{body: nil}} ->
           Logger.error("User Function Actor response Invocation body is nil")
-          {:error, :no_content}
+          {:reply, {:error, :no_content}, state}
 
         {:ok, %Tesla.Env{body: body}} ->
           with %ActorInvocationResponse{

--- a/apps/actors/lib/actors/actor/entity.ex
+++ b/apps/actors/lib/actors/actor/entity.ex
@@ -522,15 +522,8 @@ defmodule Actors.Actor.Entity do
          } = state
        ) do
     if Enum.member?(@default_methods, command) do
-      {context, current_state} =
-        case actor_state do
-          nil ->
-            {Context.new(), nil}
-
-          _ ->
-            %ActorState{state: current_state} = actor_state
-            {Context.new(state: current_state), current_state}
-        end
+      current_state = get_in(actor_state, [:state])
+      context = Context.new(state: current_state)
 
       resp =
         ActorInvocationResponse.new(

--- a/apps/actors/lib/actors/actor/entity.ex
+++ b/apps/actors/lib/actors/actor/entity.ex
@@ -217,33 +217,11 @@ defmodule Actors.Actor.Entity do
         _from,
         %EntityState{
           system: actor_system,
-          actor: %Actor{state: current_state = _actor_state} = _state_actor
-        } = state
-      )
-      when is_nil(current_state) do
-    ActorInvocation.new(
-      actor_name: name,
-      actor_system: actor_system,
-      command_name: command,
-      value: payload,
-      current_context: Context.new()
-    )
-    |> invoke_host(state)
-  end
-
-  def handle_call(
-        {:invocation_request,
-         %InvocationRequest{
-           actor: %Actor{name: name} = _actor,
-           command_name: command,
-           value: payload
-         } = _invocation},
-        _from,
-        %EntityState{
-          system: actor_system,
-          actor: %Actor{state: %ActorState{state: current_state} = _actor_state} = _state_actor
+          actor: %Actor{state: actor_state}
         } = state
       ) do
+    current_state = actor_state.state
+
     ActorInvocation.new(
       actor_name: name,
       actor_system: actor_system,
@@ -522,7 +500,7 @@ defmodule Actors.Actor.Entity do
          } = state
        ) do
     if Enum.member?(@default_methods, command) do
-      current_state = get_in(actor_state, [:state])
+      current_state = actor_state.state
       context = Context.new(state: current_state)
 
       resp =

--- a/apps/actors/lib/actors/actor/entity.ex
+++ b/apps/actors/lib/actors/actor/entity.ex
@@ -19,13 +19,21 @@ defmodule Actors.Actor.Entity do
     InvocationRequest
   }
 
-  @min_snapshot_threshold 500
+  @default_deactivate_timeout 90_000
+
+  @default_methods [
+    "get",
+    "Get",
+    "get_state",
+    "getState",
+    "GetState"
+  ]
 
   @default_snapshot_timeout 60_000
 
-  @default_deactivate_timeout 90_000
-
   @fullsweep_after 10
+
+  @min_snapshot_threshold 500
 
   @timeout_factor_range 200..9000
 
@@ -199,7 +207,6 @@ defmodule Actors.Actor.Entity do
       ),
       do: {:reply, {:ok, actor_state}, state, :hibernate}
 
-  @impl true
   def handle_call(
         {:invocation_request,
          %InvocationRequest{
@@ -214,51 +221,16 @@ defmodule Actors.Actor.Entity do
         } = state
       )
       when is_nil(current_state) do
-    payload =
-      ActorInvocation.new(
-        actor_name: name,
-        actor_system: actor_system,
-        command_name: command,
-        value: payload,
-        current_context: Context.new()
-      )
-      |> ActorInvocation.encode()
-
-    case Actors.Node.Client.invoke_host_actor(payload) do
-      {:ok, %Tesla.Env{body: ""}} ->
-        Logger.error("User Function Actor response Invocation body is empty")
-        {:error, :no_content}
-
-      {:ok, %Tesla.Env{body: nil}} ->
-        Logger.error("User Function Actor response Invocation body is nil")
-        {:error, :no_content}
-
-      {:ok, %Tesla.Env{body: body}} ->
-        with %ActorInvocationResponse{
-               updated_context: %Context{} = user_ctx
-             } = resp <- ActorInvocationResponse.decode(body) do
-          {:reply, {:ok, resp}, update_state(state, user_ctx)}
-        else
-          error ->
-            Logger.error("Error on parse response #{inspect(error)}")
-            {:reply, {:error, :invalid_content}, state, :hibernate}
-        end
-
-      {:error, timeout} ->
-        Logger.error("User Function Actor Invocation Timeout Error")
-        {:reply, {:error, timeout}, state, :hibernate}
-
-      {:error, reason} ->
-        Logger.error("User Function Actor Invocation Unknown Error: #{inspect(reason)}")
-        {:reply, {:error, reason}, state, :hibernate}
-
-      error ->
-        Logger.error("User Function Actor Invocation Unknown Error")
-        {:reply, {:error, error}, state, :hibernate}
-    end
+    ActorInvocation.new(
+      actor_name: name,
+      actor_system: actor_system,
+      command_name: command,
+      value: payload,
+      current_context: Context.new()
+    )
+    |> invoke_host(state)
   end
 
-  @impl true
   def handle_call(
         {:invocation_request,
          %InvocationRequest{
@@ -272,48 +244,14 @@ defmodule Actors.Actor.Entity do
           actor: %Actor{state: %ActorState{state: current_state} = _actor_state} = _state_actor
         } = state
       ) do
-    payload =
-      ActorInvocation.new(
-        actor_name: name,
-        actor_system: actor_system,
-        command_name: command,
-        value: payload,
-        current_context: Context.new(state: current_state)
-      )
-      |> ActorInvocation.encode()
-
-    case Actors.Node.Client.invoke_host_actor(payload) do
-      {:ok, %Tesla.Env{body: ""}} ->
-        Logger.error("User Function Actor response Invocation body is empty")
-        {:error, :no_content}
-
-      {:ok, %Tesla.Env{body: nil}} ->
-        Logger.error("User Function Actor response Invocation body is nil")
-        {:error, :no_content}
-
-      {:ok, %Tesla.Env{body: body}} ->
-        with %ActorInvocationResponse{
-               updated_context: %Context{} = user_ctx
-             } = resp <- ActorInvocationResponse.decode(body) do
-          {:reply, {:ok, resp}, update_state(state, user_ctx)}
-        else
-          error ->
-            Logger.error("Error on parse response #{inspect(error)}")
-            {:reply, {:error, :invalid_content}, state, :hibernate}
-        end
-
-      {:error, timeout} ->
-        Logger.error("User Function Actor Invocation Timeout Error")
-        {:reply, {:error, timeout}, state, :hibernate}
-
-      {:error, reason} ->
-        Logger.error("User Function Actor Invocation Unknown Error: #{inspect(reason)}")
-        {:reply, {:error, reason}, state, :hibernate}
-
-      error ->
-        Logger.error("User Function Actor Invocation Unknown Error")
-        {:reply, {:error, error}, state, :hibernate}
-    end
+    ActorInvocation.new(
+      actor_name: name,
+      actor_system: actor_system,
+      command_name: command,
+      value: payload,
+      current_context: Context.new(state: current_state)
+    )
+    |> invoke_host(state)
   end
 
   @impl true
@@ -574,6 +512,64 @@ defmodule Actors.Actor.Entity do
        ) do
     new_state = %{actor_state | state: updated_state}
     %{state | actor: %{actor | state: new_state}}
+  end
+
+  defp invoke_host(
+         %ActorInvocation{actor_name: name, actor_system: system, command_name: command} =
+           payload,
+         %EntityState{
+           actor: %Actor{state: actor_state}
+         } = state
+       ) do
+    if Enum.member?(@default_methods, command) do
+      {context, current_state} =
+        case actor_state do
+          nil ->
+            {Context.new(), nil}
+
+          _ ->
+            %ActorState{state: current_state} = actor_state
+            {Context.new(state: current_state), current_state}
+        end
+
+      resp =
+        ActorInvocationResponse.new(
+          actor_name: name,
+          actor_system: system,
+          updated_context: context,
+          value: current_state
+        )
+
+      {:reply, {:ok, resp}, state}
+    else
+      payload
+      |> ActorInvocation.encode()
+      |> Actors.Node.Client.invoke_host_actor()
+      |> case do
+        {:ok, %Tesla.Env{body: ""}} ->
+          Logger.error("User Function Actor response Invocation body is empty")
+          {:error, :no_content}
+
+        {:ok, %Tesla.Env{body: nil}} ->
+          Logger.error("User Function Actor response Invocation body is nil")
+          {:error, :no_content}
+
+        {:ok, %Tesla.Env{body: body}} ->
+          with %ActorInvocationResponse{
+                 updated_context: %Context{} = user_ctx
+               } = resp <- ActorInvocationResponse.decode(body) do
+            {:reply, {:ok, resp}, update_state(state, user_ctx)}
+          else
+            error ->
+              Logger.error("Error on parse response #{inspect(error)}")
+              {:reply, {:error, :invalid_content}, state, :hibernate}
+          end
+
+        {:error, reason} ->
+          Logger.error("User Function Actor Invocation Unknown Error: #{inspect(reason)}")
+          {:reply, {:error, reason}, state, :hibernate}
+      end
+    end
   end
 
   defp via(name) do

--- a/apps/spawn/lib/protos/actors/actor/actor.pb.ex
+++ b/apps/spawn/lib/protos/actors/actor/actor.pb.ex
@@ -56,9 +56,10 @@ defmodule Eigr.Functions.Protocol.Actors.Registry.ActorsEntry do
     }
   end
 
-  field :key, 1, type: :string
-  field :value, 2, type: Eigr.Functions.Protocol.Actors.Actor
+  field(:key, 1, type: :string)
+  field(:value, 2, type: Eigr.Functions.Protocol.Actors.Actor)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.Registry do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -146,11 +147,13 @@ defmodule Eigr.Functions.Protocol.Actors.Registry do
     }
   end
 
-  field :actors, 1,
+  field(:actors, 1,
     repeated: true,
     type: Eigr.Functions.Protocol.Actors.Registry.ActorsEntry,
     map: true
+  )
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorSystem do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -201,9 +204,10 @@ defmodule Eigr.Functions.Protocol.Actors.ActorSystem do
     }
   end
 
-  field :name, 1, type: :string
-  field :registry, 2, type: Eigr.Functions.Protocol.Actors.Registry
+  field(:name, 1, type: :string)
+  field(:registry, 2, type: Eigr.Functions.Protocol.Actors.Registry)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -246,10 +250,11 @@ defmodule Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy do
     }
   end
 
-  oneof :strategy, 0
+  oneof(:strategy, 0)
 
-  field :timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0
+  field(:timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -292,10 +297,11 @@ defmodule Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy do
     }
   end
 
-  oneof :strategy, 0
+  oneof(:strategy, 0)
 
-  field :timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0
+  field(:timeout, 1, type: Eigr.Functions.Protocol.Actors.TimeoutStrategy, oneof: 0)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.TimeoutStrategy do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -332,8 +338,9 @@ defmodule Eigr.Functions.Protocol.Actors.TimeoutStrategy do
     }
   end
 
-  field :timeout, 1, type: :int64
+  field(:timeout, 1, type: :int64)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorState.TagsEntry do
   @moduledoc false
   use Protobuf, map: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -392,9 +399,10 @@ defmodule Eigr.Functions.Protocol.Actors.ActorState.TagsEntry do
     }
   end
 
-  field :key, 1, type: :string
-  field :value, 2, type: :string
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.ActorState do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -496,13 +504,15 @@ defmodule Eigr.Functions.Protocol.Actors.ActorState do
     }
   end
 
-  field :tags, 1,
+  field(:tags, 1,
     repeated: true,
     type: Eigr.Functions.Protocol.Actors.ActorState.TagsEntry,
     map: true
+  )
 
-  field :state, 2, type: Google.Protobuf.Any
+  field(:state, 2, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.Actors.Actor do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -595,15 +605,17 @@ defmodule Eigr.Functions.Protocol.Actors.Actor do
     }
   end
 
-  field :name, 1, type: :string
-  field :persistent, 2, type: :bool
-  field :state, 3, type: Eigr.Functions.Protocol.Actors.ActorState
+  field(:name, 1, type: :string)
+  field(:persistent, 2, type: :bool)
+  field(:state, 3, type: Eigr.Functions.Protocol.Actors.ActorState)
 
-  field :snapshot_strategy, 4,
+  field(:snapshot_strategy, 4,
     type: Eigr.Functions.Protocol.Actors.ActorSnapshotStrategy,
     json_name: "snapshotStrategy"
+  )
 
-  field :deactivate_strategy, 5,
+  field(:deactivate_strategy, 5,
     type: Eigr.Functions.Protocol.Actors.ActorDeactivateStrategy,
     json_name: "deactivateStrategy"
+  )
 end

--- a/apps/spawn/lib/protos/actors/actor/protocol.pb.ex
+++ b/apps/spawn/lib/protos/actors/actor/protocol.pb.ex
@@ -39,11 +39,12 @@ defmodule Eigr.Functions.Protocol.Status do
     }
   end
 
-  field :UNKNOWN, 0
-  field :OK, 1
-  field :ACTOR_NOT_FOUND, 2
-  field :ERROR, 3
+  field(:UNKNOWN, 0)
+  field(:OK, 1)
+  field(:ACTOR_NOT_FOUND, 2)
+  field(:ERROR, 3)
 end
+
 defmodule Eigr.Functions.Protocol.SpawnRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -80,10 +81,12 @@ defmodule Eigr.Functions.Protocol.SpawnRequest do
     }
   end
 
-  field :actor_system, 2,
+  field(:actor_system, 2,
     type: Eigr.Functions.Protocol.Actors.ActorSystem,
     json_name: "actorSystem"
+  )
 end
+
 defmodule Eigr.Functions.Protocol.SpawnResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -120,8 +123,9 @@ defmodule Eigr.Functions.Protocol.SpawnResponse do
     }
   end
 
-  field :status, 1, type: Eigr.Functions.Protocol.RequestStatus
+  field(:status, 1, type: Eigr.Functions.Protocol.RequestStatus)
 end
+
 defmodule Eigr.Functions.Protocol.RegistrationRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -172,12 +176,14 @@ defmodule Eigr.Functions.Protocol.RegistrationRequest do
     }
   end
 
-  field :service_info, 1, type: Eigr.Functions.Protocol.ServiceInfo, json_name: "serviceInfo"
+  field(:service_info, 1, type: Eigr.Functions.Protocol.ServiceInfo, json_name: "serviceInfo")
 
-  field :actor_system, 2,
+  field(:actor_system, 2,
     type: Eigr.Functions.Protocol.Actors.ActorSystem,
     json_name: "actorSystem"
+  )
 end
+
 defmodule Eigr.Functions.Protocol.ServiceInfo do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -298,14 +304,15 @@ defmodule Eigr.Functions.Protocol.ServiceInfo do
     }
   end
 
-  field :service_name, 1, type: :string, json_name: "serviceName"
-  field :service_version, 2, type: :string, json_name: "serviceVersion"
-  field :service_runtime, 3, type: :string, json_name: "serviceRuntime"
-  field :support_library_name, 4, type: :string, json_name: "supportLibraryName"
-  field :support_library_version, 5, type: :string, json_name: "supportLibraryVersion"
-  field :protocol_major_version, 6, type: :int32, json_name: "protocolMajorVersion"
-  field :protocol_minor_version, 7, type: :int32, json_name: "protocolMinorVersion"
+  field(:service_name, 1, type: :string, json_name: "serviceName")
+  field(:service_version, 2, type: :string, json_name: "serviceVersion")
+  field(:service_runtime, 3, type: :string, json_name: "serviceRuntime")
+  field(:support_library_name, 4, type: :string, json_name: "supportLibraryName")
+  field(:support_library_version, 5, type: :string, json_name: "supportLibraryVersion")
+  field(:protocol_major_version, 6, type: :int32, json_name: "protocolMajorVersion")
+  field(:protocol_minor_version, 7, type: :int32, json_name: "protocolMinorVersion")
 end
+
 defmodule Eigr.Functions.Protocol.ProxyInfo do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -384,11 +391,12 @@ defmodule Eigr.Functions.Protocol.ProxyInfo do
     }
   end
 
-  field :protocol_major_version, 1, type: :int32, json_name: "protocolMajorVersion"
-  field :protocol_minor_version, 2, type: :int32, json_name: "protocolMinorVersion"
-  field :proxy_name, 3, type: :string, json_name: "proxyName"
-  field :proxy_version, 4, type: :string, json_name: "proxyVersion"
+  field(:protocol_major_version, 1, type: :int32, json_name: "protocolMajorVersion")
+  field(:protocol_minor_version, 2, type: :int32, json_name: "protocolMinorVersion")
+  field(:proxy_name, 3, type: :string, json_name: "proxyName")
+  field(:proxy_version, 4, type: :string, json_name: "proxyVersion")
 end
+
 defmodule Eigr.Functions.Protocol.RegistrationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -439,9 +447,10 @@ defmodule Eigr.Functions.Protocol.RegistrationResponse do
     }
   end
 
-  field :status, 1, type: Eigr.Functions.Protocol.RequestStatus
-  field :proxy_info, 2, type: Eigr.Functions.Protocol.ProxyInfo, json_name: "proxyInfo"
+  field(:status, 1, type: Eigr.Functions.Protocol.RequestStatus)
+  field(:proxy_info, 2, type: Eigr.Functions.Protocol.ProxyInfo, json_name: "proxyInfo")
 end
+
 defmodule Eigr.Functions.Protocol.Context do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -478,8 +487,9 @@ defmodule Eigr.Functions.Protocol.Context do
     }
   end
 
-  field :state, 1, type: Google.Protobuf.Any
+  field(:state, 1, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.InvocationRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -572,12 +582,13 @@ defmodule Eigr.Functions.Protocol.InvocationRequest do
     }
   end
 
-  field :system, 1, type: Eigr.Functions.Protocol.Actors.ActorSystem
-  field :actor, 2, type: Eigr.Functions.Protocol.Actors.Actor
-  field :command_name, 3, type: :string, json_name: "commandName"
-  field :value, 4, type: Google.Protobuf.Any
-  field :async, 5, type: :bool
+  field(:system, 1, type: Eigr.Functions.Protocol.Actors.ActorSystem)
+  field(:actor, 2, type: Eigr.Functions.Protocol.Actors.Actor)
+  field(:command_name, 3, type: :string, json_name: "commandName")
+  field(:value, 4, type: Google.Protobuf.Any)
+  field(:async, 5, type: :bool)
 end
+
 defmodule Eigr.Functions.Protocol.ActorInvocation do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -670,12 +681,13 @@ defmodule Eigr.Functions.Protocol.ActorInvocation do
     }
   end
 
-  field :actor_name, 1, type: :string, json_name: "actorName"
-  field :actor_system, 2, type: :string, json_name: "actorSystem"
-  field :command_name, 3, type: :string, json_name: "commandName"
-  field :current_context, 4, type: Eigr.Functions.Protocol.Context, json_name: "currentContext"
-  field :value, 5, type: Google.Protobuf.Any
+  field(:actor_name, 1, type: :string, json_name: "actorName")
+  field(:actor_system, 2, type: :string, json_name: "actorSystem")
+  field(:command_name, 3, type: :string, json_name: "commandName")
+  field(:current_context, 4, type: Eigr.Functions.Protocol.Context, json_name: "currentContext")
+  field(:value, 5, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.ActorInvocationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -754,11 +766,12 @@ defmodule Eigr.Functions.Protocol.ActorInvocationResponse do
     }
   end
 
-  field :actor_name, 1, type: :string, json_name: "actorName"
-  field :actor_system, 2, type: :string, json_name: "actorSystem"
-  field :updated_context, 3, type: Eigr.Functions.Protocol.Context, json_name: "updatedContext"
-  field :value, 4, type: Google.Protobuf.Any
+  field(:actor_name, 1, type: :string, json_name: "actorName")
+  field(:actor_system, 2, type: :string, json_name: "actorSystem")
+  field(:updated_context, 3, type: Eigr.Functions.Protocol.Context, json_name: "updatedContext")
+  field(:value, 4, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.InvocationResponse do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -837,11 +850,12 @@ defmodule Eigr.Functions.Protocol.InvocationResponse do
     }
   end
 
-  field :status, 1, type: Eigr.Functions.Protocol.RequestStatus
-  field :system, 2, type: Eigr.Functions.Protocol.Actors.ActorSystem
-  field :actor, 3, type: Eigr.Functions.Protocol.Actors.Actor
-  field :value, 4, type: Google.Protobuf.Any
+  field(:status, 1, type: Eigr.Functions.Protocol.RequestStatus)
+  field(:system, 2, type: Eigr.Functions.Protocol.Actors.ActorSystem)
+  field(:actor, 3, type: Eigr.Functions.Protocol.Actors.Actor)
+  field(:value, 4, type: Google.Protobuf.Any)
 end
+
 defmodule Eigr.Functions.Protocol.RequestStatus do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -892,6 +906,6 @@ defmodule Eigr.Functions.Protocol.RequestStatus do
     }
   end
 
-  field :status, 1, type: Eigr.Functions.Protocol.Status, enum: true
-  field :message, 2, type: :string
+  field(:status, 1, type: Eigr.Functions.Protocol.Status, enum: true)
+  field(:message, 2, type: :string)
 end

--- a/apps/spawn/lib/protos/cloudevents/spec.pb.ex
+++ b/apps/spawn/lib/protos/cloudevents/spec.pb.ex
@@ -56,9 +56,10 @@ defmodule Io.Cloudevents.V1.CloudEvent.AttributesEntry do
     }
   end
 
-  field :key, 1, type: :string
-  field :value, 2, type: Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue
+  field(:key, 1, type: :string)
+  field(:value, 2, type: Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue)
 end
+
 defmodule Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -181,16 +182,17 @@ defmodule Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue do
     }
   end
 
-  oneof :attr, 0
+  oneof(:attr, 0)
 
-  field :ce_boolean, 1, type: :bool, json_name: "ceBoolean", oneof: 0
-  field :ce_integer, 2, type: :int32, json_name: "ceInteger", oneof: 0
-  field :ce_string, 3, type: :string, json_name: "ceString", oneof: 0
-  field :ce_bytes, 4, type: :bytes, json_name: "ceBytes", oneof: 0
-  field :ce_uri, 5, type: :string, json_name: "ceUri", oneof: 0
-  field :ce_uri_ref, 6, type: :string, json_name: "ceUriRef", oneof: 0
-  field :ce_timestamp, 7, type: Google.Protobuf.Timestamp, json_name: "ceTimestamp", oneof: 0
+  field(:ce_boolean, 1, type: :bool, json_name: "ceBoolean", oneof: 0)
+  field(:ce_integer, 2, type: :int32, json_name: "ceInteger", oneof: 0)
+  field(:ce_string, 3, type: :string, json_name: "ceString", oneof: 0)
+  field(:ce_bytes, 4, type: :bytes, json_name: "ceBytes", oneof: 0)
+  field(:ce_uri, 5, type: :string, json_name: "ceUri", oneof: 0)
+  field(:ce_uri_ref, 6, type: :string, json_name: "ceUriRef", oneof: 0)
+  field(:ce_timestamp, 7, type: Google.Protobuf.Timestamp, json_name: "ceTimestamp", oneof: 0)
 end
+
 defmodule Io.Cloudevents.V1.CloudEvent do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -496,19 +498,20 @@ defmodule Io.Cloudevents.V1.CloudEvent do
     }
   end
 
-  oneof :data, 0
+  oneof(:data, 0)
 
-  field :id, 1, type: :string
-  field :source, 2, type: :string
-  field :spec_version, 3, type: :string, json_name: "specVersion"
-  field :type, 4, type: :string
+  field(:id, 1, type: :string)
+  field(:source, 2, type: :string)
+  field(:spec_version, 3, type: :string, json_name: "specVersion")
+  field(:type, 4, type: :string)
 
-  field :attributes, 5,
+  field(:attributes, 5,
     repeated: true,
     type: Io.Cloudevents.V1.CloudEvent.AttributesEntry,
     map: true
+  )
 
-  field :binary_data, 6, type: :bytes, json_name: "binaryData", oneof: 0
-  field :text_data, 7, type: :string, json_name: "textData", oneof: 0
-  field :proto_data, 8, type: Google.Protobuf.Any, json_name: "protoData", oneof: 0
+  field(:binary_data, 6, type: :bytes, json_name: "binaryData", oneof: 0)
+  field(:text_data, 7, type: :string, json_name: "textData", oneof: 0)
+  field(:proto_data, 8, type: Google.Protobuf.Any, json_name: "protoData", oneof: 0)
 end

--- a/apps/spawn/lib/protos/google/protobuf/any.pb.ex
+++ b/apps/spawn/lib/protos/google/protobuf/any.pb.ex
@@ -48,6 +48,6 @@ defmodule Google.Protobuf.Any do
     }
   end
 
-  field :type_url, 1, type: :string, json_name: "typeUrl"
-  field :value, 2, type: :bytes
+  field(:type_url, 1, type: :string, json_name: "typeUrl")
+  field(:value, 2, type: :bytes)
 end


### PR DESCRIPTION
This PR adds default methods for actor state search operations.

Any invoke operation for methods with the names in the list below will result in the return of the current state of the Actor.
In my tests I noticed improvements of up to 10x for some cases in the speed with which the state is returned. But for a few cases the performance was worse. I will perform more accurate tests but this does not affect the state of this PR which can be completed without further issues about performance.

Method names supported:

```elixir
@default_methods [
    "get",
    "Get",
    "get_state",
    "getState",
    "GetState"
  ]
```