### PR TITLE
Add mongodb statestore

### DIFF
--- a/apps/statestores/lib/statestores/adapters/mongodb.ex
+++ b/apps/statestores/lib/statestores/adapters/mongodb.ex
@@ -1,0 +1,37 @@
+defmodule Statestores.Adapters.MongoDB do
+  use Statestores.Adapters.Behaviour
+
+  use Ecto.Repo,
+    otp_app: :statestores,
+    adapter: Mongo.Ecto
+
+  alias Statestores.Schemas.{Event, ValueObjectSchema}
+
+  def get_by_key(actor), do: get_by(Event, actor: actor)
+
+  def save(%Event{revision: revision, tags: tags, data_type: type, data: data} = event) do
+    %Event{}
+    |> Event.changeset(ValueObjectSchema.to_map(event))
+    |> insert_or_update!(
+      on_conflict: [
+        set: [
+          revision: revision,
+          tags: tags,
+          data_type: type,
+          data: data,
+          updated_at: DateTime.utc_now()
+        ]
+      ]
+    )
+    |> case do
+      {:ok, event} ->
+        {:ok, event}
+
+      {:error, changeset} ->
+        {:error, changeset}
+
+      other ->
+        {:error, other}
+    end
+  end
+end

--- a/apps/statestores/lib/statestores/util.ex
+++ b/apps/statestores/lib/statestores/util.ex
@@ -11,6 +11,7 @@ defmodule Statestores.Util do
           | Statestores.Adapters.Postgres
           | Statestores.Adapters.SQLite3
           | Statestores.Adapters.MSSQL
+          | Statestores.Adapters.MongoDB
   def load_repo() do
     type = String.to_existing_atom(System.get_env("PROXY_DATABASE_TYPE", "mysql"))
     load_repo(type)
@@ -26,6 +27,8 @@ defmodule Statestores.Util do
 
   def load_repo(:mssql), do: Statestores.Adapters.MSSQL
 
+  def load_repo(:mongodb), do: Statestores.Adapters.MongoDB
+
   @spec get_default_database_port :: <<_::32>>
   def get_default_database_port() do
     String.to_existing_atom(System.get_env("PROXY_DATABASE_TYPE", "mysql"))
@@ -40,4 +43,6 @@ defmodule Statestores.Util do
   def get_default_database_port(:sqlite), do: "0"
 
   def get_default_database_port(:mssql), do: "1433"
+
+  def get_default_database_port(:mongodb), do: "27017"
 end

--- a/apps/statestores/mix.exs
+++ b/apps/statestores/mix.exs
@@ -30,11 +30,12 @@ defmodule Statestores.MixProject do
     [
       {:spawn, "~> 0.1", in_umbrella: true, only: :test},
       {:cloak_ecto, "~> 1.2"},
-      {:ecto_sql, "~> 3.8"},
-      {:ecto_sqlite3, "~> 0.8.2"},
+      {:ecto_sql, "~> 3.9"},
+      {:ecto_sqlite3, "~> 0.8"},
       {:myxql, "~> 0.6"},
       {:postgrex, "~> 0.16"},
-      {:tds, "~> 2.3"}
+      {:tds, "~> 2.3"},
+      {:mongodb_ecto, "~> 1.0.0-beta.2"}
     ]
   end
 

--- a/apps/statestores/priv/mongodb/migrations/20220521162410_create_events_table.exs
+++ b/apps/statestores/priv/mongodb/migrations/20220521162410_create_events_table.exs
@@ -1,0 +1,20 @@
+defmodule Statestores.Adapters.MongoDB.Migrations.CreateEventsTable do
+  use Ecto.Migration
+
+  def up do
+    create table(:events, primary_key: false) do
+      add :actor, :string, primary_key: true
+      add :system, :string
+      add :revision, :integer
+      add :tags, :map
+      add :data_type, :string
+      add :data, :binary
+      timestamps([type: :utc_datetime_usec])
+    end
+
+  end
+
+  def down do
+    drop table(:events)
+  end
+end


### PR DESCRIPTION
It looks like the library for Mongodb is out of date.

Run Mongodb Docker:

```
docker run --name eigr-mongodb -p 27017:27017 -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=admin -e MONGO_INITDB_DATABASE=eigr-function-db -d mongo:4.4.4
```

Run Proxy:

```
MIX_ENV=prod PROXY_CLUSTER_STRATEGY=epmd PROXY_DATABASE_TYPE=mongodb PROXY_DATABASE_USERNAME=admin PROXY_DATABASE_SECRET=admin PROXY_DATABASE_NAME=admin SPAWN_STATESTORE_KEY=3Jnb0hZiHIzHTOih7t2cTEPEpY98Tu1wvQkPfq/XwqE= iex --name spawn_a3@127.0.0.1 -S mix
```

Error on startup
```
2022-10-18 22:41:21.587 [spawn_a3@127.0.0.1]:[pid=<0.810.0> ]:[error]:Could not create schema migrations table. This error usually happens due to the following:

  * The database does not exist
  * The "schema_migrations" table, which Ecto uses for managing
    migrations, was defined by another library
  * There is a deadlock while migrating (such as using concurrent
    indexes with a migration_lock)

To fix the first issue, run "mix ecto.create".

To address the second, you can run "mix ecto.drop" followed by
"mix ecto.create". Alternatively you may configure Ecto to use
another table and/or repository for managing migrations:

    config :statestores, Statestores.Adapters.MongoDB,
      migration_source: "some_other_table_for_schema_migrations",
      migration_repo: AnotherRepoForSchemaMigrations

The full error report is shown below.

2022-10-18 22:41:21.599 [spawn_a3@127.0.0.1]:[pid=<0.44.0> ]:[notice]:Application spawn_federated_example exited: SpawnFederatedExample.Application.start(:normal, []) returned an error: shutdown: failed to start child: SpawnSdk.System.Supervisor
    ** (EXIT) shutdown: failed to start child: Sidecar.Supervisor
        ** (EXIT) shutdown: failed to start child: Statestores.Supervisor
            ** (EXIT) an exception was raised:
                ** (UndefinedFunctionError) function Mongo.Ecto.execute_ddl/3 is undefined or private
                    (mongodb_ecto 1.0.0-beta.2) Mongo.Ecto.execute_ddl(%{adapter: Mongo.Ecto, cache: #Reference<0.1218499883.92143617.7262>, opts: [queue_target: 10000, pool_size: 60, timeout: 15000], pid: #PID<0.812.0>, pool: {Statestores.Adapters.MongoDB.Pool, [pool_timeout: 5000, repo: Statestores.Adapters.MongoDB, queue_target: 10000, pool_size: 60, port: 27017, hostname: "localhost", password: "admin", username: "admin", database: "admin", telemetry_prefix: [:statestores, :adapters, :mongo_db], otp_app: :statestores, timeout: 15000]}, repo: Statestores.Adapters.MongoDB, telemetry: {Statestores.Adapters.MongoDB, :debug, [:statestores, :adapters, :mongo_db, :query]}}, {:create_if_not_exists, %Ecto.Migration.Table{name: :schema_migrations, prefix: nil, comment: nil, primary_key: true, engine: nil, options: nil}, [{:add, :version, :bigint, [primary_key: true]}, {:add, :inserted_at, :naive_datetime, []}]}, [timeout: :infinity, log: false, schema_migration: true, telemetry_options: [schema_migration: true]])
                    (ecto_sql 3.9.0) lib/ecto/migrator.ex:672: Ecto.Migrator.verbose_schema_migration/3
                    (ecto_sql 3.9.0) lib/ecto/migrator.ex:486: Ecto.Migrator.lock_for_migrations/4
                    (ecto_sql 3.9.0) lib/ecto/migrator.ex:398: Ecto.Migrator.run/4
                    (ecto_sql 3.9.0) lib/ecto/migrator.ex:146: Ecto.Migrator.with_repo/3
                    (statestores 0.1.0) lib/statestores/migrator/migrator.ex:9: Statestores.Migrator.migrate/0
                    (statestores 0.1.0) lib/statestores/supervisor.ex:20: Statestores.Supervisor.init/1
                    (stdlib 4.1) supervisor.erl:330: :supervisor.init/1
{"Kernel pid terminated",application_controller,"{application_start_failure,spawn_federated_example,{{shutdown,{failed_to_start_child,'Elixir.SpawnSdk.System.Supervisor',{shutdown,{failed_to_start_child,'Elixir.Sidecar.Supervisor',{shutdown,{failed_to_start_child,'Elixir.Statestores.Supervisor',{#{'__exception__' => true,'__struct__' => 'Elixir.UndefinedFunctionError',arity => 3,function => execute_ddl,message => nil,module => 'Elixir.Mongo.Ecto',reason => nil},[{'Elixir.Mongo.Ecto',execute_ddl,[#{adapter => 'Elixir.Mongo.Ecto',cache => #Ref<0.1218499883.92143617.7262>,opts => [{queue_target,10000},{pool_size,60},{timeout,15000}],pid => <0.812.0>,pool => {'Elixir.Statestores.Adapters.MongoDB.Pool',[{pool_timeout,5000},{repo,'Elixir.Statestores.Adapters.MongoDB'},{queue_target,10000},{pool_size,60},{port,27017},{hostname,<<\"localhost\">>},{password,<<\"admin\">>},{username,<<\"admin\">>},{database,<<\"admin\">>},{telemetry_prefix,[statestores,adapters,mongo_db]},{otp_app,statestores},{timeout,15000}]},repo => 'Elixir.Statestores.Adapters.MongoDB',telemetry => {'Elixir.Statestores.Adapters.MongoDB',debug,[statestores,adapters,mongo_db,query]}},{create_if_not_exists,#{'__struct__' => 'Elixir.Ecto.Migration.Table',comment => nil,engine => nil,name => schema_migrations,options => nil,prefix => nil,primary_key => true},[{add,version,bigint,[{primary_key,true}]},{add,inserted_at,naive_datetime,[]}]},[{timeout,infinity},{log,false},{schema_migration,true},{telemetry_options,[{schema_migration,true}]}]],[]},{'Elixir.Ecto.Migrator',verbose_schema_migration,3,[{file,\"lib/ecto/migrator.ex\"},{line,672}]},{'Elixir.Ecto.Migrator',lock_for_migrations,4,[{file,\"lib/ecto/migrator.ex\"},{line,486}]},{'Elixir.Ecto.Migrator',run,4,[{file,\"lib/ecto/migrator.ex\"},{line,398}]},{'Elixir.Ecto.Migrator',with_repo,3,[{file,\"lib/ecto/migrator.ex\"},{line,146}]},{'Elixir.Statestores.Migrator',migrate,0,[{file,\"lib/statestores/migrator/migrator.ex\"},{line,9}]},{'Elixir.Statestores.Supervisor',init,1,[{file,\"lib/statestores/supervisor.ex\"},{line,20}]},{supervisor,init,1,[{file,\"supervisor.erl\"},{line,330}]}]}}}}}}},{'Elixir.SpawnFederatedExample.Application',start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,spawn_federated_example,{{shutdown,{failed_to_start_child,'Elixir.SpawnSdk.System.Supervisor',{shutdown,{failed_to_start_child,'Elixir.Sidecar.Supervisor',{shutdown,{failed_to_start_child,'Elixir.Statestores.Supervisor',{#{'__exception__' => true,'__struct__' => 'Elixir.UndefinedFunctionError',arity => 3,function => execute_ddl,message => nil,module => 'Elixir.Mongo.Ecto',reason => nil},[{'Elixir.Mongo.Ecto',execute_ddl,[#{adapter => 'Elixir.Mongo.Ecto',cache => #Ref<0.1218499883.92143617.7262>,opts => [{queue_target,10000},{pool_size,60},{timeout,15000}],pid => <0.812.0>,pool => {'Elixir.Statestores.Adapters.MongoDB.Pool',[{pool_timeout,5000},{repo,'Elixir.Statestores.Adapters.MongoDB'},{queue_target,10000},{pool_size,60},{port,27017},{hostname,<<"localhost">>},{password,<<"admin">>},{username,<<"admin">>},{database,<<"admin">>},{telemetry_prefix,[statestores,adapters,mongo_db]},{otp_app,statestores},{timeout,15000}]},repo => 'Elixir
```