### PR TITLE
Added mnesia statestore

### DIFF
--- a/apps/spawn/lib/spawn/cloudevents/spec.pb.ex
+++ b/apps/spawn/lib/spawn/cloudevents/spec.pb.ex
@@ -56,9 +56,10 @@ defmodule Io.Cloudevents.V1.CloudEvent.AttributesEntry do
     }
   end
 
-  field :key, 1, type: :string
-  field :value, 2, type: Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue
+  field(:key, 1, type: :string)
+  field(:value, 2, type: Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue)
 end
+
 defmodule Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -181,16 +182,17 @@ defmodule Io.Cloudevents.V1.CloudEvent.CloudEventAttributeValue do
     }
   end
 
-  oneof :attr, 0
+  oneof(:attr, 0)
 
-  field :ce_boolean, 1, type: :bool, json_name: "ceBoolean", oneof: 0
-  field :ce_integer, 2, type: :int32, json_name: "ceInteger", oneof: 0
-  field :ce_string, 3, type: :string, json_name: "ceString", oneof: 0
-  field :ce_bytes, 4, type: :bytes, json_name: "ceBytes", oneof: 0
-  field :ce_uri, 5, type: :string, json_name: "ceUri", oneof: 0
-  field :ce_uri_ref, 6, type: :string, json_name: "ceUriRef", oneof: 0
-  field :ce_timestamp, 7, type: Google.Protobuf.Timestamp, json_name: "ceTimestamp", oneof: 0
+  field(:ce_boolean, 1, type: :bool, json_name: "ceBoolean", oneof: 0)
+  field(:ce_integer, 2, type: :int32, json_name: "ceInteger", oneof: 0)
+  field(:ce_string, 3, type: :string, json_name: "ceString", oneof: 0)
+  field(:ce_bytes, 4, type: :bytes, json_name: "ceBytes", oneof: 0)
+  field(:ce_uri, 5, type: :string, json_name: "ceUri", oneof: 0)
+  field(:ce_uri_ref, 6, type: :string, json_name: "ceUriRef", oneof: 0)
+  field(:ce_timestamp, 7, type: Google.Protobuf.Timestamp, json_name: "ceTimestamp", oneof: 0)
 end
+
 defmodule Io.Cloudevents.V1.CloudEvent do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -496,19 +498,20 @@ defmodule Io.Cloudevents.V1.CloudEvent do
     }
   end
 
-  oneof :data, 0
+  oneof(:data, 0)
 
-  field :id, 1, type: :string
-  field :source, 2, type: :string
-  field :spec_version, 3, type: :string, json_name: "specVersion"
-  field :type, 4, type: :string
+  field(:id, 1, type: :string)
+  field(:source, 2, type: :string)
+  field(:spec_version, 3, type: :string, json_name: "specVersion")
+  field(:type, 4, type: :string)
 
-  field :attributes, 5,
+  field(:attributes, 5,
     repeated: true,
     type: Io.Cloudevents.V1.CloudEvent.AttributesEntry,
     map: true
+  )
 
-  field :binary_data, 6, type: :bytes, json_name: "binaryData", oneof: 0
-  field :text_data, 7, type: :string, json_name: "textData", oneof: 0
-  field :proto_data, 8, type: Google.Protobuf.Any, json_name: "protoData", oneof: 0
+  field(:binary_data, 6, type: :bytes, json_name: "binaryData", oneof: 0)
+  field(:text_data, 7, type: :string, json_name: "textData", oneof: 0)
+  field(:proto_data, 8, type: Google.Protobuf.Any, json_name: "protoData", oneof: 0)
 end

--- a/apps/spawn/lib/spawn/google/protobuf/any.pb.ex
+++ b/apps/spawn/lib/spawn/google/protobuf/any.pb.ex
@@ -48,6 +48,6 @@ defmodule Google.Protobuf.Any do
     }
   end
 
-  field :type_url, 1, type: :string, json_name: "typeUrl"
-  field :value, 2, type: :bytes
+  field(:type_url, 1, type: :string, json_name: "typeUrl")
+  field(:value, 2, type: :bytes)
 end

--- a/apps/statestores/lib/statestores/adapters/mnesia.ex
+++ b/apps/statestores/lib/statestores/adapters/mnesia.ex
@@ -1,0 +1,27 @@
+defmodule Statestores.Adapters.Mnesia do
+  use Statestores.Adapters.Behaviour
+
+  use Ecto.Repo,
+    otp_app: :statestores,
+    adapter: Ecto.Adapters.Mnesia
+
+  alias Statestores.Schemas.{Event, ValueObjectSchema}
+
+  def get_by_key(actor), do: get_by(Event, actor: actor)
+
+  def save(%Event{revision: revision, tags: tags, data_type: type, data: data} = event) do
+    %Event{}
+    |> Event.changeset(ValueObjectSchema.to_map(event))
+    |> insert_or_update!(on_conflict: :replace)
+    |> case do
+      {:ok, event} ->
+        {:ok, event}
+
+      {:error, changeset} ->
+        {:error, changeset}
+
+      other ->
+        {:error, other}
+    end
+  end
+end

--- a/apps/statestores/lib/statestores/util.ex
+++ b/apps/statestores/lib/statestores/util.ex
@@ -6,39 +6,44 @@ defmodule Statestores.Util do
     Application.load(@otp_app)
   end
 
-  @spec get_database_type() :: :cockroachdb | :mysql | :postgres | :sqlite | :mssql | :mongodb
+  @spec get_database_type() ::
+          :cockroachdb | :mongodb | :mssql | :mysql | :native | :postgres | :sqlite
   def get_database_type() do
     String.to_existing_atom(System.get_env("PROXY_DATABASE_TYPE", "mysql"))
   end
 
   @spec load_repo ::
-          Statestores.Adapters.MySQL
+          Statestores.Adapters.Mnesia
+          | Statestores.Adapters.MongoDB
+          | Statestores.Adapters.MSSQL
+          | Statestores.Adapters.MySQL
           | Statestores.Adapters.Postgres
           | Statestores.Adapters.SQLite3
-          | Statestores.Adapters.MSSQL
-          | Statestores.Adapters.MongoDB
   def load_repo() do
     type = String.to_existing_atom(System.get_env("PROXY_DATABASE_TYPE", "mysql"))
     load_repo(type)
   end
 
-  @spec load_repo(:cockroachdb | :mysql | :postgres | :sqlite | :mssql | :mongodb) ::
-          Statestores.Adapters.MySQL
+  @spec load_repo(:cockroachdb | :mongodb | :mssql | :mysql | :native | :postgres | :sqlite) ::
+          Statestores.Adapters.Mnesia
+          | Statestores.Adapters.MongoDB
+          | Statestores.Adapters.MSSQL
+          | Statestores.Adapters.MySQL
           | Statestores.Adapters.Postgres
           | Statestores.Adapters.SQLite3
-          | Statestores.Adapters.MSSQL
-          | Statestores.Adapters.MongoDB
   def load_repo(:cockroachdb), do: Statestores.Adapters.Postgres
-
-  def load_repo(:mysql), do: Statestores.Adapters.MySQL
-
-  def load_repo(:postgres), do: Statestores.Adapters.Postgres
-
-  def load_repo(:sqlite), do: Statestores.Adapters.SQLite3
 
   def load_repo(:mssql), do: Statestores.Adapters.MSSQL
 
   def load_repo(:mongodb), do: Statestores.Adapters.MongoDB
+
+  def load_repo(:mysql), do: Statestores.Adapters.MySQL
+
+  def load_repo(:native), do: Statestores.Adapters.Mnesia
+
+  def load_repo(:postgres), do: Statestores.Adapters.Postgres
+
+  def load_repo(:sqlite), do: Statestores.Adapters.SQLite3
 
   @spec get_default_database_port :: <<_::32>>
   def get_default_database_port() do
@@ -49,13 +54,15 @@ defmodule Statestores.Util do
   @spec get_default_database_port(:mysql | :postgres) :: <<_::32>>
   def get_default_database_port(:cockroachdb), do: "26257"
 
+  def get_default_database_port(:mongodb), do: "27017"
+
+  def get_default_database_port(:mssql), do: "1433"
+
   def get_default_database_port(:mysql), do: "3306"
+
+  def get_default_database_port(:native), do: "0"
 
   def get_default_database_port(:postgres), do: "5432"
 
   def get_default_database_port(:sqlite), do: "0"
-
-  def get_default_database_port(:mssql), do: "1433"
-
-  def get_default_database_port(:mongodb), do: "27017"
 end

--- a/apps/statestores/mix.exs
+++ b/apps/statestores/mix.exs
@@ -30,6 +30,7 @@ defmodule Statestores.MixProject do
     [
       {:spawn, "~> 0.1", in_umbrella: true, only: :test},
       {:cloak_ecto, "~> 1.2"},
+      {:ecto3_mnesia, "~> 0.2.0"},
       {:ecto_sql, "~> 3.8"},
       {:ecto_sqlite3, "~> 0.8.2"},
       {:myxql, "~> 0.6"},

--- a/apps/statestores/priv/mnesia/migrations/20220521162410_create_events_table.exs
+++ b/apps/statestores/priv/mnesia/migrations/20220521162410_create_events_table.exs
@@ -1,0 +1,14 @@
+defmodule Statestores.Adapters.Mnesia.Migrations.CreateEventsTable do
+  use Ecto.Migration
+
+  def up do
+
+    IO.inspect :mnesia.create_table(:events, [
+      disc_copies: [node()],
+      record_name: Statestores.Schemas.Event,
+      attributes: [:actor, :system, :revision, :tags, :data_type, :data, :updated_at, :inserted_at],
+      type: :set
+    ])
+  end
+
+end


### PR DESCRIPTION
It looks like the library for Ecto Mnesia is out of date.

Run proxy:

```
MIX_ENV=prod PROXY_CLUSTER_STRATEGY=epmd PROXY_DATABASE_TYPE=native PROXY_DATABASE_NAME=eigr-functions-db  SPAWN_STATESTORE_KEY=3Jnb0hZiHIzHTOih7t2cTEPEpY98Tu1wvQkPfq/XwqE= iex --name spawn_a3@127.0.0.1 -S mix
```

Error on startup
```
2022-10-18 23:39:37.585 [spawn_a3@127.0.0.1]:[pid=<0.44.0> ]:[notice]:Application spawn_federated_example exited: SpawnFederatedExample.Application.start(:normal, []) returned an error: shutdown: failed to start child: SpawnSdk.System.Supervisor
    ** (EXIT) shutdown: failed to start child: Sidecar.Supervisor
        ** (EXIT) shutdown: failed to start child: Statestores.Supervisor
            ** (EXIT) an exception was raised:
                ** (UndefinedFunctionError) function Ecto.Adapters.Mnesia.execute_ddl/3 is undefined or private
                    (ecto3_mnesia 0.2.2) Ecto.Adapters.Mnesia.execute_ddl(%{adapter: Ecto.Adapters.Mnesia, cache: #Reference<0.2829300223.906625026.234028>, pid: #PID<0.6484.0>, repo: Statestores.Adapters.Mnesia}, {:create_if_not_exists, %Ecto.Migration.Table{name: :schema_migrations, prefix: nil, comment: nil, primary_key: true, engine: nil, options: nil}, [{:add, :version, :bigint, [primary_key: true]}, {:add, :inserted_at, :naive_datetime, []}]}, [timeout: :infinity, log: false, schema_migration: true, telemetry_options: [schema_migration: true]])
                    (ecto_sql 3.9.0) lib/ecto/migrator.ex:672: Ecto.Migrator.verbose_schema_migration/3
                    (ecto_sql 3.9.0) lib/ecto/migrator.ex:486: Ecto.Migrator.lock_for_migrations/4
                    (ecto_sql 3.9.0) lib/ecto/migrator.ex:398: Ecto.Migrator.run/4
                    (ecto_sql 3.9.0) lib/ecto/migrator.ex:146: Ecto.Migrator.with_repo/3
                    (statestores 0.1.0) lib/statestores/migrator/migrator.ex:9: Statestores.Migrator.migrate/0
                    (statestores 0.1.0) lib/statestores/supervisor.ex:20: Statestores.Supervisor.init/1
                    (stdlib 4.1) supervisor.erl:330: :supervisor.init/1
{"Kernel pid terminated",application_controller,"{application_start_failure,spawn_federated_example,{{shutdown,{failed_to_start_child,'Elixir.SpawnSdk.System.Supervisor',{shutdown,{failed_to_start_child,'Elixir.Sidecar.Supervisor',{shutdown,{failed_to_start_child,'Elixir.Statestores.Supervisor',{#{'__exception__' => true,'__struct__' => 'Elixir.UndefinedFunctionError',arity => 3,function => execute_ddl,message => nil,module => 'Elixir.Ecto.Adapters.Mnesia',reason => nil},[{'Elixir.Ecto.Adapters.Mnesia',execute_ddl,[#{adapter => 'Elixir.Ecto.Adapters.Mnesia',cache => #Ref<0.2829300223.906625026.234028>,pid => <0.6484.0>,repo => 'Elixir.Statestores.Adapters.Mnesia'},{create_if_not_exists,#{'__struct__' => 'Elixir.Ecto.Migration.Table',comment => nil,engine => nil,name => schema_migrations,options => nil,prefix => nil,primary_key => true},[{add,version,bigint,[{primary_key,true}]},{add,inserted_at,naive_datetime,[]}]},[{timeout,infinity},{log,false},{schema_migration,true},{telemetry_options,[{schema_migration,true}]}]],[]},{'Elixir.Ecto.Migrator',verbose_schema_migration,3,[{file,\"lib/ecto/migrator.ex\"},{line,672}]},{'Elixir.Ecto.Migrator',lock_for_migrations,4,[{file,\"lib/ecto/migrator.ex\"},{line,486}]},{'Elixir.Ecto.Migrator',run,4,[{file,\"lib/ecto/migrator.ex\"},{line,398}]},{'Elixir.Ecto.Migrator',with_repo,3,[{file,\"lib/ecto/migrator.ex\"},{line,146}]},{'Elixir.Statestores.Migrator',migrate,0,[{file,\"lib/statestores/migrator/migrator.ex\"},{line,9}]},{'Elixir.Statestores.Supervisor',init,1,[{file,\"lib/statestores/supervisor.ex\"},{line,20}]},{supervisor,init,1,[{file,\"supervisor.erl\"},{line,330}]}]}}}}}}},{'Elixir.SpawnFederatedExample.Application',start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,spawn_federated_example,{{shutdown,{failed_to_start_child,'Elixir.SpawnSdk.System.Supervisor',{shutdown,{failed_to_start_child,'Elixir.Sidecar.Supervisor',{shutdown,{failed_to_start_child,'Elixir.Statestores.Supervisor',{#{'__exception__' => true,'__struct__' => 'Elixir.UndefinedFunctionError',arity => 3,function => execute_ddl,message => nil,module => 'Elixir.Ecto.Adapters.Mnesia',reason => nil},[{'Elixir.Ecto.Adapters.Mnesia',execute_ddl,[#{adapter => 'Elixir.Ecto.Adapters.Mnesia',cache => #Ref<0.2829300223.906625026.234028>,pid => <0.6484.0>,repo => 'Elixir.Statestores.Adapters.Mnesia'},{create_if_not_exists,#{'__struct__' => 'Elixir.Ecto.Migration.Table',comment => nil,engine => nil,name => schema_migrations,options => nil,prefix => nil,primary_key => true},[{add,version,bigint,[{primary_key,true}]},{add,inserted_at,naive_datetime,[]}]},[{timeout,infinity},{log,false},{schema_migration,true},{telemetry_options,[{schema_migration,t

Crash dump is being written to: erl_crash.dump...done
```