### PR TITLE
Spawn actor by string instead of module name

### DIFF
--- a/spawn_sdk/spawn_sdk/README.md
+++ b/spawn_sdk/spawn_sdk/README.md
@@ -525,7 +525,7 @@ The full example of this application can be found [here](https://github.com/eigr
   Spawning Actors:
 
   ```elixir
-  iex> SpawnSdk.spawn_actor("robert", system: "spawn-system", actor: SpawnSdkExample.Actors.AbstractActor)
+  iex> SpawnSdk.spawn_actor("robert", system: "spawn-system", actor: "abs_actor")
   {:ok, %{"robert" => SpawnSdkExample.Actors.AbstractActor}}
   ```
 

--- a/spawn_sdk/spawn_sdk_example/lib/spawn_sdk_example/actors/abstract_actor.ex
+++ b/spawn_sdk/spawn_sdk_example/lib/spawn_sdk_example/actors/abstract_actor.ex
@@ -1,5 +1,6 @@
 defmodule SpawnSdkExample.Actors.AbstractActor do
   use SpawnSdk.Actor,
+    name: "abs_actor",
     abstract: true,
     state_type: Io.Eigr.Spawn.Example.MyState
 


### PR DESCRIPTION
Fixes: https://github.com/eigr/spawn/issues/99

This makes it possible to spawn_actor by string or module name

However, still its only possible to spawn actors that are registered in the current instance, its not the proxy that deals with this registration

We can now use:

```ELIXIR
SpawnSdk.spawn_actor("custom_id", system: "spawn-system", actor: "abs_actor")

# AND ALSO

SpawnSdk.invoke("custom_id", system: "spawn-system", ref: "abs_actor", command: "get")

```