### PR TITLE
Remove entity get state

### DIFF
--- a/lib/actors.ex
+++ b/lib/actors.ex
@@ -10,7 +10,6 @@ defmodule Actors do
   require OpenTelemetry.Tracer, as: Tracer
 
   alias Actors.Actor.Entity, as: ActorEntity
-  alias Actors.Actor.Entity.EntityState
   alias Actors.Actor.Entity.Supervisor, as: ActorEntitySupervisor
   alias Actors.Actor.InvocationScheduler
 
@@ -171,7 +170,7 @@ defmodule Actors do
            caller: caller,
            pooled: pooled?
          } = request,
-         opts \\ []
+         opts
        ) do
     {time, result} =
       :timer.tc(fn ->

--- a/lib/actors.ex
+++ b/lib/actors.ex
@@ -337,24 +337,10 @@ defmodule Actors do
       Tracer.set_attributes([{:actor_fqdn, actor_fqdn}])
 
       case Spawn.Cluster.Node.Registry.lookup(Actors.Actor.Entity, parent) do
-        [{actor_ref, _}] ->
+        [{actor_ref, actor_ref_id}] ->
           Tracer.add_event("actor-status", [{"alive", true}])
           Tracer.set_attributes([{"actor-pid", "#{inspect(actor_ref)}"}])
           Logger.debug("Lookup Actor #{actor_name}. PID: #{inspect(actor_ref)}")
-
-          actor_ref_id =
-            try do
-              %EntityState{actor: %Actor{id: %ActorId{} = actor_ref_id}} =
-                :sys.get_state(actor_ref, 1000)
-                |> EntityState.unpack()
-
-              actor_ref_id
-            catch
-              e ->
-                Logger.warning(
-                  "Failure during get_state to actor #{actor_name}. Error #{inspect(e)}"
-                )
-            end
 
           if pooled,
             # Ensures that the name change will not affect the host function call

--- a/lib/actors/actor/entity/lifecycle.ex
+++ b/lib/actors/actor/entity/lifecycle.ex
@@ -15,8 +15,7 @@ defmodule Actors.Actor.Entity.Lifecycle do
     ActorState,
     ActorSnapshotStrategy,
     Metadata,
-    TimeoutStrategy,
-    Kind
+    TimeoutStrategy
   }
 
   alias Phoenix.PubSub
@@ -44,7 +43,7 @@ defmodule Actors.Actor.Entity.Lifecycle do
                 snapshot_strategy: snapshot_strategy,
                 deactivation_strategy: deactivation_strategy,
                 kind: kind
-              } = settings,
+              } = _settings,
             timer_commands: timer_commands
           }
         } = state

--- a/lib/spawn/cluster/node/registry.ex
+++ b/lib/spawn/cluster/node/registry.ex
@@ -29,6 +29,13 @@ defmodule Spawn.Cluster.Node.Registry do
   end
 
   @doc """
+  Update value meta inside registry
+  """
+  def update_entry_value(mod, actor_name, pid, value) do
+    GenServer.call(__MODULE__, {:update_value, {mod, actor_name}, pid, value})
+  end
+
+  @doc """
   Check if Process is alive.
   """
   def isAlive(mod, actor_name) do


### PR DESCRIPTION
This fixes the bug of :sys.get_state firing a timeout

This way we can put a value to the registry data, everytime we do a Spawn.Cluster.Node.Registry.lookup we will also receive the actorId with it