### PR TITLE
Trap exit invocation scheduler fix

### DIFF
--- a/lib/actors/actor/invocation_scheduler.ex
+++ b/lib/actors/actor/invocation_scheduler.ex
@@ -19,6 +19,7 @@ defmodule Actors.Actor.InvocationScheduler do
 
   @impl true
   def init(_arg) do
+    Process.flag(:trap_exit, true)
     Process.flag(:message_queue_data, :off_heap)
     {:ok, %{}, {:continue, :init_invocations}}
   end
@@ -31,6 +32,11 @@ defmodule Actors.Actor.InvocationScheduler do
     Enum.each(stored_invocations, &call_invoke/1)
 
     {:noreply, state}
+  end
+
+  @impl true
+  def terminate(reason, _state) do
+    Logger.debug("InvocationScheduler down with reason (#{inspect(reason)})")
   end
 
   @impl true


### PR DESCRIPTION
We were using this in Highlander, but Highlander docs itself says that your process need to trap exit to work with Highlander.

We were getting the following error:

```
2023-04-19 02:55:24.773 [spawn@10.42.0.125]:[pid=<0.2786.0> ]:[error]:GenServer #PID<0.2786.0> terminating
** (stop) exited in: GenServer.stop(#PID<0.2787.0>, {:function_clause, [{Highlander, :handle_info, [{:EXIT, #PID<0.2787.0>, :shutdown}, %{child_spec: %{id: Actors.Actor.InvocationScheduler, restart: :transient, start: {Actors.Actor.InvocationScheduler, :start_link, []}}, pid: #PID<0.2787.0>}], [file: 'lib/highlander.ex', line: 90]}, {:gen_server, :try_dispatch, 4, [file: 'gen_server.erl', line: 1123]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 1200]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}]}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.14.0) lib/gen_server.ex:995: GenServer.stop/3
    (highlander 0.2.1) lib/highlander.ex:101: Highlander.terminate/2
    (stdlib 4.1) gen_server.erl:1161: :gen_server.try_terminate/3
    (stdlib 4.1) gen_server.erl:1351: :gen_server.terminate/10
    (stdlib 4.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: {:EXIT, #PID<0.2787.0>, :shutdown}
State: %{child_spec: %{id: Actors.Actor.InvocationScheduler, restart: :transient, start: {Actors.Actor.InvocationScheduler, :start_link, []}}, pid: #PID<0.2787.0>}
```
