### PR TITLE
Added support to pod anti affinity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ run-sdk-local2:
 	cd spawn_sdk/spawn_sdk_example && PROXY_CLUSTER_STRATEGY=gossip PROXY_DATABASE_TYPE=$(database) SPAWN_STATESTORE_KEY=3Jnb0hZiHIzHTOih7t2cTEPEpY98Tu1wvQkPfq/XwqE= iex --name spawn_actors_node3@127.0.0.1 -S mix
 
 run-operator-local:
-	cd spawn_operator/spawn_operator && mix deps.get && MIX_ENV=dev iex --name operator@127.0.0.1 -S mix
+	cd spawn_operator/spawn_operator && mix deps.get && MIX_ENV=dev BONNY_POD_NAME=spawn-operator iex --name operator@127.0.0.1 -S mix
 	
 run-activator-local:
 	cd spawn_activators/activator && mix deps.get && MIX_ENV=dev iex --name activator@127.0.0.1 -S mix

--- a/spawn_operator/spawn_operator/test/resources/actorhost/deployment_test.exs
+++ b/spawn_operator/spawn_operator/test/resources/actorhost/deployment_test.exs
@@ -55,6 +55,27 @@ defmodule DeploymentTest do
                      "labels" => %{"actor-system" => "spawn-system", "app" => "spawn-test"}
                    },
                    "spec" => %{
+                     "affinity" => %{
+                       "podAntiAffinity" => %{
+                         "preferredDuringSchedulingIgnoredDuringExecution" => [
+                           %{
+                             "podAffinityTerm" => %{
+                               "labelSelector" => %{
+                                 "matchExpressions" => [
+                                   %{
+                                     "key" => "app",
+                                     "operator" => "In",
+                                     "values" => ["spawn-test"]
+                                   }
+                                 ]
+                               },
+                               "topologyKey" => "kubernetes.io/hostname"
+                             },
+                             "weight" => 100
+                           }
+                         ]
+                       }
+                     },
                      "containers" => [
                        %{
                          "env" => [
@@ -129,6 +150,27 @@ defmodule DeploymentTest do
                      "labels" => %{"actor-system" => "spawn-system", "app" => "spawn-test"}
                    },
                    "spec" => %{
+                     "affinity" => %{
+                       "podAntiAffinity" => %{
+                         "preferredDuringSchedulingIgnoredDuringExecution" => [
+                           %{
+                             "podAffinityTerm" => %{
+                               "labelSelector" => %{
+                                 "matchExpressions" => [
+                                   %{
+                                     "key" => "app",
+                                     "operator" => "In",
+                                     "values" => ["spawn-test"]
+                                   }
+                                 ]
+                               },
+                               "topologyKey" => "kubernetes.io/hostname"
+                             },
+                             "weight" => 100
+                           }
+                         ]
+                       }
+                     },
                      "containers" => [
                        %{
                          "env" => [
@@ -207,6 +249,27 @@ defmodule DeploymentTest do
                      "labels" => %{"actor-system" => "spawn-system", "app" => "spawn-test"}
                    },
                    "spec" => %{
+                     "affinity" => %{
+                       "podAntiAffinity" => %{
+                         "preferredDuringSchedulingIgnoredDuringExecution" => [
+                           %{
+                             "podAffinityTerm" => %{
+                               "labelSelector" => %{
+                                 "matchExpressions" => [
+                                   %{
+                                     "key" => "app",
+                                     "operator" => "In",
+                                     "values" => ["spawn-test"]
+                                   }
+                                 ]
+                               },
+                               "topologyKey" => "kubernetes.io/hostname"
+                             },
+                             "weight" => 100
+                           }
+                         ]
+                       }
+                     },
                      "containers" => [
                        %{
                          "env" => [
@@ -306,6 +369,27 @@ defmodule DeploymentTest do
                "spec" => %{
                  "template" => %{
                    "spec" => %{
+                     "affinity" => %{
+                       "podAntiAffinity" => %{
+                         "preferredDuringSchedulingIgnoredDuringExecution" => [
+                           %{
+                             "podAffinityTerm" => %{
+                               "labelSelector" => %{
+                                 "matchExpressions" => [
+                                   %{
+                                     "key" => "app",
+                                     "operator" => "In",
+                                     "values" => ["spawn-test"]
+                                   }
+                                 ]
+                               },
+                               "topologyKey" => "kubernetes.io/hostname"
+                             },
+                             "weight" => 100
+                           }
+                         ]
+                       }
+                     },
                      "containers" => containers
                    }
                  }
@@ -352,6 +436,27 @@ defmodule DeploymentTest do
                "spec" => %{
                  "template" => %{
                    "spec" => %{
+                     "affinity" => %{
+                       "podAntiAffinity" => %{
+                         "preferredDuringSchedulingIgnoredDuringExecution" => [
+                           %{
+                             "podAffinityTerm" => %{
+                               "labelSelector" => %{
+                                 "matchExpressions" => [
+                                   %{
+                                     "key" => "app",
+                                     "operator" => "In",
+                                     "values" => ["spawn-test"]
+                                   }
+                                 ]
+                               },
+                               "topologyKey" => "kubernetes.io/hostname"
+                             },
+                             "weight" => 100
+                           }
+                         ]
+                       }
+                     },
                      "containers" => containers,
                      "volumes" => [%{"emptyDir" => "{}", "name" => "volume-name"}]
                    }


### PR DESCRIPTION
This adds support for [anti affinity Pod](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)