### PR TITLE
Remove migration lock for all databases

### DIFF
--- a/spawn_statestores/statestores/lib/statestores/adapters/behaviour.ex
+++ b/spawn_statestores/statestores/lib/statestores/adapters/behaviour.ex
@@ -43,19 +43,7 @@ defmodule Statestores.Adapters.Behaviour do
         hostname = System.get_env("PROXY_DATABASE_HOST", "localhost")
 
         config = Keyword.put(config, :hostname, hostname)
-
-        config =
-          case System.get_env("PROXY_DATABASE_TYPE", get_default_database_type()) do
-            "cockroachdb" ->
-              Keyword.put(
-                config,
-                :migration_lock,
-                nil
-              )
-
-            _ ->
-              config
-          end
+        config = Keyword.put(config, :migration_lock, nil)
 
         config =
           Keyword.put(


### PR DESCRIPTION
We don't actually need migration locks for spawn, right, why would we need it?

Removing it would support managed dbs such as planetscaleDB or cockroachDB out of the box