### PR TITLE
State handoff join syncer

### DIFF
--- a/lib/sidecar/process_supervisor.ex
+++ b/lib/sidecar/process_supervisor.ex
@@ -10,23 +10,7 @@ defmodule Sidecar.ProcessSupervisor do
         {Sidecar.MetricsSupervisor, config},
         Spawn.Supervisor.child_spec(config),
         Actors.Supervisors.ProtocolSupervisor.child_spec(config),
-        Actors.Supervisors.ActorSupervisor.child_spec(config),
-        %{
-          id: StateHandoffJoinTask,
-          restart: :transient,
-          start: {
-            Task,
-            :start_link,
-            [
-              fn ->
-                Node.list()
-                |> Enum.each(fn node ->
-                  Spawn.Cluster.StateHandoff.join(node)
-                end)
-              end
-            ]
-          }
-        }
+        Actors.Supervisors.ActorSupervisor.child_spec(config)
       ]
       |> Enum.reject(&is_nil/1)
 

--- a/lib/spawn/cluster/state_handoff.ex
+++ b/lib/spawn/cluster/state_handoff.ex
@@ -65,20 +65,20 @@ defmodule Spawn.Cluster.StateHandoff do
   def handle_info(:set_neighbours, this_crdt_pid) do
     nodes = Node.list()
 
-    Logger.debug(
-      "Sending :set_neighbours to #{inspect(nodes)} for #{inspect(this_crdt_pid)}"
-    )
+    Logger.debug("Sending :set_neighbours to #{inspect(nodes)} for #{inspect(this_crdt_pid)}")
 
-    neighbours = :erpc.multicall(nodes, __MODULE__, :get_crdt_pid, [])
-    |> Enum.map(fn
-      {:ok, crdt_pid} -> crdt_pid
+    neighbours =
+      :erpc.multicall(nodes, __MODULE__, :get_crdt_pid, [])
+      |> Enum.map(fn
+        {:ok, crdt_pid} ->
+          crdt_pid
 
-      _ ->
-        Logger.warning("Couldn't reach one of the nodes when calling for neighbors")
+        _ ->
+          Logger.warning("Couldn't reach one of the nodes when calling for neighbors")
 
-        nil
-    end)
-    |> Enum.reject(&is_nil/1)
+          nil
+      end)
+      |> Enum.reject(&is_nil/1)
 
     # add other_node's crdt_pid as a neighbour
     # we are not adding both ways and letting them sync with eachother

--- a/lib/spawn/cluster/state_handoff.ex
+++ b/lib/spawn/cluster/state_handoff.ex
@@ -73,8 +73,10 @@ defmodule Spawn.Cluster.StateHandoff do
         {:ok, crdt_pid} ->
           crdt_pid
 
-        _ ->
-          Logger.warning("Couldn't reach one of the nodes when calling for neighbors")
+        error ->
+          Logger.warning(
+            "Couldn't reach one of the nodes when calling for neighbors -> #{inspect(error)}"
+          )
 
           nil
       end)

--- a/lib/spawn/cluster/state_handoff.ex
+++ b/lib/spawn/cluster/state_handoff.ex
@@ -18,7 +18,7 @@ defmodule Spawn.Cluster.StateHandoff do
   @default_sync_interval 5
   @default_ship_interval 5
   @default_ship_debounce 5
-  @default_neighbours_sync_interval 30_000
+  @default_neighbours_sync_interval 60_000
 
   def child_spec(opts \\ []) do
     %{

--- a/lib/spawn/cluster/state_handoff.ex
+++ b/lib/spawn/cluster/state_handoff.ex
@@ -18,6 +18,7 @@ defmodule Spawn.Cluster.StateHandoff do
   @default_sync_interval 5
   @default_ship_interval 5
   @default_ship_debounce 5
+  @default_neighbours_sync_interval 5_000
 
   def child_spec(opts \\ []) do
     %{
@@ -38,6 +39,8 @@ defmodule Spawn.Cluster.StateHandoff do
         ship_debounce: Keyword.get(opts, :ship_debounce, @default_ship_debounce)
       )
 
+    Process.send(self(), {:set_neighbours, Node.list()}, [:noconnect])
+
     {:ok, crdt_pid}
   end
 
@@ -54,24 +57,33 @@ defmodule Spawn.Cluster.StateHandoff do
   end
 
   @impl true
-  def handle_call({:set_neighbours, other_node}, _from, this_crdt_pid) do
+  def handle_info({:set_neighbours, nodes}, this_crdt_pid) do
     Logger.debug(
-      "Sending :set_neighbours to #{inspect(other_node)} with #{inspect(this_crdt_pid)}"
+      "Sending :set_neighbours to #{inspect(nodes)} for #{inspect(this_crdt_pid)}"
     )
 
-    other_crdt_pid = GenServer.call(other_node, {:fulfill_set_neighbours, this_crdt_pid})
+    neighbours = :erpc.multicall(nodes, __MODULE__, :get_crdt_pid, [])
+    |> Enum.map(fn
+      {:ok, crdt_pid} -> crdt_pid
 
-    # add other_node's crdt_pid as a neighbour, we need to add both ways so changes in either
-    # are reflected across, otherwise it would be one way only
-    DeltaCrdt.set_neighbours(this_crdt_pid, [other_crdt_pid])
+      _ ->
+        Logger.warning("Couldn't reach one of the nodes when calling for neighbors")
 
-    {:reply, :ok, this_crdt_pid}
+        nil
+    end)
+    |> Enum.reject(&is_nil/1)
+
+    # add other_node's crdt_pid as a neighbour
+    # we are not adding both ways and letting them sync with eachother
+    # based on current Node.list() of each node
+    DeltaCrdt.set_neighbours(this_crdt_pid, neighbours)
+
+    Process.send_after(self(), {:set_neighbours, Node.list()}, @default_neighbours_sync_interval)
+
+    {:noreply, this_crdt_pid}
   end
 
-  def handle_call({:fulfill_set_neighbours, other_crdt_pid}, _from, this_crdt_pid) do
-    Logger.debug("Adding neighbour #{inspect(other_crdt_pid)} to this #{inspect(this_crdt_pid)}")
-
-    DeltaCrdt.set_neighbours(this_crdt_pid, [other_crdt_pid])
+  def handle_call(:get_crdt_pid, _from, this_crdt_pid) do
     {:reply, this_crdt_pid, this_crdt_pid}
   end
 
@@ -131,14 +143,6 @@ defmodule Spawn.Cluster.StateHandoff do
   end
 
   @doc """
-  Join this crdt with one on another node by adding it as a neighbour
-  """
-  def join(other_node) do
-    Logger.debug("Joining StateHandoff at #{inspect(other_node)}")
-    GenServer.call(__MODULE__, {:set_neighbours, {__MODULE__, other_node}})
-  end
-
-  @doc """
   Store a actor and entity in the handoff crdt
   """
   def set(actor, hosts) do
@@ -150,6 +154,10 @@ defmodule Spawn.Cluster.StateHandoff do
   """
   def get(actor) do
     GenServer.call(__MODULE__, {:get, actor}, @call_timeout)
+  end
+
+  def get_crdt_pid do
+    GenServer.call(__MODULE__, :get_crdt_pid, @call_timeout)
   end
 
   def get_all_invocations do

--- a/lib/spawn/cluster/state_handoff.ex
+++ b/lib/spawn/cluster/state_handoff.ex
@@ -68,7 +68,7 @@ defmodule Spawn.Cluster.StateHandoff do
     Logger.debug("Sending :set_neighbours to #{inspect(nodes)} for #{inspect(this_crdt_pid)}")
 
     neighbours =
-      :erpc.multicall(nodes, __MODULE__, :get_crdt_pid, [])
+      :erpc.multicall(nodes, __MODULE__, :get_crdt_pid, [], @call_timeout + 1000)
       |> Enum.map(fn
         {:ok, crdt_pid} ->
           crdt_pid

--- a/test/actors/registry/actor_registry_test.exs
+++ b/test/actors/registry/actor_registry_test.exs
@@ -20,8 +20,6 @@ defmodule Actors.ActorRegistryTest do
 
     peer_node_name = :"spawn_actors_node@127.0.0.1"
 
-    assert :ok == Spawn.Cluster.StateHandoff.join(peer_node_name)
-
     assert {:ok, %RegistrationResponse{}} =
              Spawn.NodeHelper.rpc(peer_node_name, Actors, :register, [
                request


### PR DESCRIPTION
We were adding only one crdt pid in set_neighbours and thus having weird cluster issues

`DeltaCrdt.set_neighbours` function expects all of the connected pids to be passed as the second param, it doesn't make a merge if you pass only one at a time.

This also adds a healing process to the neighbours for each crdt pid.
It also gets all the pids with a `:erpc.multicast` to improve performance