### PR TITLE
Register ref on protocol instead of relying on sdk

### DIFF
--- a/lib/actors/actor/caller_producer.ex
+++ b/lib/actors/actor/caller_producer.ex
@@ -37,6 +37,15 @@ defmodule Actors.Actor.CallerProducer do
 
   @spec invoke(InvocationRequest.t()) :: {:ok, :async} | {:ok, term()} | {:error, term()}
   def invoke(request, opts \\ []) do
+    if request.register_ref != "" do
+      spawn_req = %SpawnRequest{
+        actors: [%ActorId{request.actor.id | parent: request.register_ref}]
+      }
+
+      # TODO: Verify the possibility to use cast instead of call for this
+      spawn_actor(spawn_req)
+    end
+
     GenStage.call(__MODULE__, {:enqueue, {:invoke, request, opts}}, :infinity)
   end
 

--- a/lib/spawn/actors/protocol.pb.ex
+++ b/lib/spawn/actors/protocol.pb.ex
@@ -1383,6 +1383,20 @@ defmodule Eigr.Functions.Protocol.InvocationRequest do
           proto3_optional: nil,
           type: :TYPE_BOOL,
           type_name: nil
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          __unknown_fields__: [],
+          default_value: nil,
+          extendee: nil,
+          json_name: "registerRef",
+          label: :LABEL_OPTIONAL,
+          name: "register_ref",
+          number: 11,
+          oneof_index: nil,
+          options: nil,
+          proto3_optional: nil,
+          type: :TYPE_STRING,
+          type_name: nil
         }
       ],
       name: "InvocationRequest",
@@ -1469,6 +1483,7 @@ defmodule Eigr.Functions.Protocol.InvocationRequest do
 
   field(:scheduled_to, 9, type: :int64, json_name: "scheduledTo")
   field(:pooled, 10, type: :bool)
+  field(:register_ref, 11, type: :string, json_name: "registerRef")
 end
 
 defmodule Eigr.Functions.Protocol.ActorInvocation do

--- a/priv/protos/eigr/functions/protocol/actors/protocol.proto
+++ b/priv/protos/eigr/functions/protocol/actors/protocol.proto
@@ -334,6 +334,7 @@ message Workflow {
 //   * async: Indicates whether the action should be processed synchronously, where a response should be sent back to the user function, 
 //            or whether the action should be processed asynchronously, i.e. no response sent to the caller and no waiting.
 //   * metadata: Meta information or headers
+//   * register_ref: If the invocation should register the specific actor with the given name without having to call register before
 message InvocationRequest {
 
     eigr.functions.protocol.actors.ActorSystem system = 1;
@@ -356,6 +357,8 @@ message InvocationRequest {
     int64 scheduled_to = 9;
 
     bool pooled = 10;
+
+    string register_ref = 11;
 }
 
 // ActorInvocation is a translation message between a local invocation made via InvocationRequest 

--- a/spawn_sdk/spawn_sdk/lib/actor.ex
+++ b/spawn_sdk/spawn_sdk/lib/actor.ex
@@ -328,7 +328,7 @@ defmodule SpawnSdk.Actor do
     actions = Module.get_attribute(__CALLER__.module, :defact_exports)
 
     actor_name = Keyword.get(opts, :name, Atom.to_string(__CALLER__.module))
-    actor_kind = Keyword.get(opts, :kind, :SINGLETON)
+    actor_kind = Keyword.get(opts, :kind, :NAMED) |> SpawnSdk.System.SpawnSystem.decode_kind()
     caller_module = __CALLER__.module
     channel_group = Keyword.get(opts, :channel, nil)
 
@@ -375,22 +375,7 @@ defmodule SpawnSdk.Actor do
       end
 
       def __meta__(:channel), do: unquote(channel_group)
-
-      def __meta__(:name) do
-        actor_name = unquote(actor_name)
-        kind = unquote(actor_kind)
-
-        if kind == :ABSTRACT do
-          unless :persistent_term.get("actor:#{actor_name}", false) do
-            :persistent_term.put("actor:#{actor_name}", unquote(caller_module))
-          end
-
-          actor_name
-        else
-          actor_name
-        end
-      end
-
+      def __meta__(:name), do: unquote(actor_name)
       def __meta__(:kind), do: unquote(actor_kind)
       def __meta__(:stateful), do: unquote(stateful)
       def __meta__(:state_type), do: unquote(state_type)

--- a/spawn_sdk/spawn_sdk/lib/system/spawn_system.ex
+++ b/spawn_sdk/spawn_sdk/lib/system/spawn_system.ex
@@ -103,10 +103,6 @@ defmodule SpawnSdk.System.SpawnSystem do
       raise "You have to specify an action"
     end
 
-    if actor_reference do
-      spawn_actor(actor_name, system: system, actor: actor_reference)
-    end
-
     opts = []
     payload = parse_payload(payload)
 
@@ -121,7 +117,8 @@ defmodule SpawnSdk.System.SpawnSystem do
       async: async,
       caller: nil,
       pooled: pooled,
-      scheduled_to: parse_scheduled_to(delay_in_ms, scheduled_to)
+      scheduled_to: parse_scheduled_to(delay_in_ms, scheduled_to),
+      register_ref: actor_reference
     }
 
     case Actors.invoke(req, opts) do
@@ -561,10 +558,14 @@ defmodule SpawnSdk.System.SpawnSystem do
     end)
   end
 
-  defp decode_kind(:abstract), do: :UNAMED
-  defp decode_kind(:singleton), do: :NAMED
-  defp decode_kind(:pooled), do: :POOLED
-  defp decode_kind(_), do: :UNKNOW_KIND
+  def decode_kind(:abstract), do: :UNAMED
+  def decode_kind(:ABSTRACT), do: :UNAMED
+  def decode_kind(:unamed), do: :UNAMED
+  def decode_kind(:SINGLETON), do: :NAMED
+  def decode_kind(:singleton), do: :NAMED
+  def decode_kind(:named), do: :NAMED
+  def decode_kind(:pooled), do: :POOLED
+  def decode_kind(_), do: :UNKNOW_KIND
 
   defp get_action(action_atom) do
     %Action{name: parse_action_name(action_atom)}

--- a/spawn_sdk/spawn_sdk/test/actor/actor_test.exs
+++ b/spawn_sdk/spawn_sdk/test/actor/actor_test.exs
@@ -3,6 +3,7 @@ defmodule Actor.ActorTest do
 
   defmodule Actor.MyActor do
     use SpawnSdk.Actor,
+      name: "my_actor_ref",
       kind: :abstract,
       stateful: false,
       state_type: Eigr.Spawn.Actor.MyState,
@@ -80,6 +81,7 @@ defmodule Actor.ActorTest do
 
   defmodule Actor.JsonActor do
     use SpawnSdk.Actor,
+      name: "json_actor_ref",
       kind: :abstract,
       stateful: false,
       state_type: :json
@@ -194,7 +196,7 @@ defmodule Actor.ActorTest do
     end
 
     test "get defaults" do
-      assert :abstract == Actor.MyActor.__meta__(:kind)
+      assert :UNAMED == Actor.MyActor.__meta__(:kind)
       assert false == Actor.MyActor.__meta__(:stateful)
       assert 10_000 == Actor.MyActor.__meta__(:deactivate_timeout)
       assert 2_000 == Actor.MyActor.__meta__(:snapshot_timeout)
@@ -224,19 +226,17 @@ defmodule Actor.ActorTest do
   end
 
   describe "invoke json actor" do
-    @tag :skip
     test "simple default function call returning only map without payload", ctx do
       system = ctx.system
       dynamic_actor_name = Faker.Pokemon.name() <> "json_actor_get_state"
 
       assert SpawnSdk.invoke(dynamic_actor_name,
-               ref: Actor.JsonActor,
+               ref: "json_actor_ref",
                action: "getState",
                system: system
              ) == {:ok, %{value: 0}}
     end
 
-    @tag :skip
     test "simple call using maps with no proto", ctx do
       system = ctx.system
       dynamic_actor_name = Faker.Pokemon.name() <> "json_actor_call"
@@ -244,7 +244,7 @@ defmodule Actor.ActorTest do
       payload = %{value: 2}
 
       assert SpawnSdk.invoke(dynamic_actor_name,
-               ref: Actor.JsonActor,
+               ref: "json_actor_ref",
                action: "sum",
                system: system,
                payload: payload
@@ -253,7 +253,6 @@ defmodule Actor.ActorTest do
   end
 
   describe "invoke with routing" do
-    @tag :skip
     test "simple call that goes through 3 actors piping each other", ctx do
       system = ctx.system
 
@@ -263,7 +262,7 @@ defmodule Actor.ActorTest do
 
       assert {:ok, response} =
                SpawnSdk.invoke(dynamic_actor_name,
-                 ref: Actor.MyActor,
+                 ref: "my_actor_ref",
                  system: system,
                  action: "pipe_caller",
                  payload: payload
@@ -272,55 +271,51 @@ defmodule Actor.ActorTest do
       assert %{data: "second_actor as caller to third_actor"} = response
     end
 
-    @tag :skip
     test "calling a function that sets wrong state type", ctx do
       system = ctx.system
       dynamic_actor_name = Faker.Pokemon.name() <> "wrong_state"
 
       assert SpawnSdk.invoke(dynamic_actor_name,
-               ref: Actor.MyActor,
+               ref: "my_actor_ref",
                system: system,
                action: "wrong_state"
              ) == {:ok, nil}
 
       assert SpawnSdk.invoke(dynamic_actor_name,
-               ref: Actor.MyActor,
+               ref: "my_actor_ref",
                action: "getState",
                system: system
              ) == {:error, :invalid_state_output}
     end
 
-    @tag :skip
     test "calling a function that sets wrong state type to json", ctx do
       system = ctx.system
       dynamic_actor_name = Faker.Pokemon.name() <> "wrong_state_json"
 
       assert SpawnSdk.invoke(dynamic_actor_name,
-               ref: Actor.MyActor,
+               ref: "my_actor_ref",
                system: system,
                action: "wrong_state_json"
              ) == {:ok, nil}
 
       assert SpawnSdk.invoke(dynamic_actor_name,
-               ref: Actor.MyActor,
+               ref: "my_actor_ref",
                system: system,
                action: "get_state"
              ) == {:ok, nil}
     end
 
-    @tag :skip
     test "calling a function that returns json in response", ctx do
       system = ctx.system
       dynamic_actor_name = Faker.Pokemon.name() <> "json_return"
 
       assert SpawnSdk.invoke(dynamic_actor_name,
-               ref: Actor.MyActor,
+               ref: "my_actor_ref",
                system: system,
                action: "json_return"
              ) == {:ok, %{test: true}}
     end
 
-    @tag :skip
     test "simple call that goes through 3 actors forwarding each other", ctx do
       system = ctx.system
 
@@ -330,7 +325,7 @@ defmodule Actor.ActorTest do
 
       assert {:ok, response} =
                SpawnSdk.invoke(dynamic_actor_name,
-                 ref: Actor.MyActor,
+                 ref: "my_actor_ref",
                  system: system,
                  action: "forward_caller",
                  payload: payload
@@ -344,7 +339,6 @@ defmodule Actor.ActorTest do
   end
 
   describe "invoke with side effect" do
-    @tag :skip
     test "simple call with a side effect", ctx do
       system = ctx.system
 
@@ -354,7 +348,7 @@ defmodule Actor.ActorTest do
 
       assert {:ok, response} =
                SpawnSdk.invoke(dynamic_actor_name,
-                 ref: Actor.MyActor,
+                 ref: "my_actor_ref",
                  system: system,
                  action: "use_side_effect",
                  payload: payload
@@ -365,7 +359,6 @@ defmodule Actor.ActorTest do
   end
 
   describe "tags" do
-    @tag :skip
     test "simple call verifying that tags is changed", ctx do
       system = ctx.system
 
@@ -373,7 +366,7 @@ defmodule Actor.ActorTest do
 
       assert {:ok, response} =
                SpawnSdk.invoke(dynamic_actor_name,
-                 ref: Actor.MyActor,
+                 ref: "my_actor_ref",
                  system: system,
                  action: "change_tags"
                )
@@ -382,7 +375,7 @@ defmodule Actor.ActorTest do
 
       assert {:ok, response} =
                SpawnSdk.invoke(dynamic_actor_name,
-                 ref: Actor.MyActor,
+                 ref: "my_actor_ref",
                  system: system,
                  action: "change_tags"
                )


### PR DESCRIPTION
This makes it possible so that SDKS can invoke named actors without having to spawn them first and without SDK calling proxy two times