### PR TITLE
Fix unnamed typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,10 +122,10 @@ The Spawn protocol is very simple to implement but it is necessary for the devel
    
    For a more complete understanding, see the example in Java of how the Actors are registered and how the Spawning of these Actors is performed on the fly:
 
-      * First an Actor is defined and its identity is defined as Unamed.
-        https://github.com/eigr/spawn-springboot-sdk/blob/main/spawn-springboot-examples/src/main/java/io/eigr/spawn/example/UnamedActor.java
+      * First an Actor is defined and its identity is defined as Unnamed.
+        https://github.com/eigr/spawn-springboot-sdk/blob/main/spawn-springboot-examples/src/main/java/io/eigr/spawn/example/UnnamedActor.java
 
-      * Then, when you really want to create a concrete instance of this Actor, a real name is given and this name is associated with the unamed type of the Actor.  
+      * Then, when you really want to create a concrete instance of this Actor, a real name is given and this name is associated with the unnamed type of the Actor.  
         https://github.com/eigr/spawn-springboot-sdk/blob/e88b59f1505647a867adb9607a4d39baa249ebb2/spawn-springboot-examples/src/main/java/io/eigr/spawn/example/App.java#L36
 
 6. **Raise your hand and seek help:**

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -66,7 +66,7 @@ invocation request type bytes encoded here :-)
 
 Actors are usually created at the beginning of the SDK's communication flow with the Proxy by the registration step described above. 
 However, some use cases require that Actors can be created ***on the fly***. 
-In other words, Spawn is used to bring to life Actors previously registered as Unamed, giving them a name and thus creating a concrete instance at runtime for that Actor. Actors created with the Spawn feature are generally used when you want to share a behavior while maintaining the isolation characteristics of the actors.
+In other words, Spawn is used to bring to life Actors previously registered as Unnamed, giving them a name and thus creating a concrete instance at runtime for that Actor. Actors created with the Spawn feature are generally used when you want to share a behavior while maintaining the isolation characteristics of the actors.
 For these situations we have the Spawning flow described below. 
 
 A user function that wants to Spawning new Actors in Proxy Spawn must proceed by making a POST request to the following endpoint:

--- a/lib/actors/actor/caller_consumer.ex
+++ b/lib/actors/actor/caller_consumer.ex
@@ -282,7 +282,7 @@ defmodule Actors.Actor.CallerConsumer do
 
           error ->
             raise ArgumentError,
-                  "You are trying to create an actor from an Unamed actor that has never been registered before. ActorId: #{inspect(id)}. Details. #{inspect(error)}"
+                  "You are trying to create an actor from an Unnamed actor that has never been registered before. ActorId: #{inspect(id)}. Details. #{inspect(error)}"
         end
       end)
       |> List.flatten()
@@ -449,10 +449,10 @@ defmodule Actors.Actor.CallerConsumer do
   defp to_spawn_hosts(id, actor_hosts, spawned_opts) do
     Enum.map(actor_hosts, fn %HostActor{
                                node: node,
-                               actor: %Actor{} = unamed_actor,
+                               actor: %Actor{} = unnamed_actor,
                                opts: opts
                              } = _host ->
-      spawned_actor = %Actor{unamed_actor | id: id}
+      spawned_actor = %Actor{unnamed_actor | id: id}
 
       new_opts =
         if Keyword.has_key?(spawned_opts, :revision) do
@@ -721,7 +721,7 @@ defmodule Actors.Actor.CallerConsumer do
       kind == :POOLED ->
         false
 
-      match?(true, stateful) and kind != :UNAMED ->
+      match?(true, stateful) and kind != :UNNAMED ->
         true
 
       not is_nil(channel_group) and length(channel_group) > 0 ->

--- a/lib/actors/actors.ex
+++ b/lib/actors/actors.ex
@@ -47,8 +47,8 @@ defmodule Actors do
     * `opts` - The options to create Actors
 
   spawn_actor must be used when you want to create a concrete instance of an actor
-  previously registered as unamed.
-  That is, when an Actorid is associated with an actor of unamed type.
+  previously registered as unnamed.
+  That is, when an Actorid is associated with an actor of unnamed type.
   This function only registers the metadata of the new actor, not activating it.
   This will occur when the sprite is first invoked.
   ##

--- a/lib/spawn/actors/actor.pb.ex
+++ b/lib/spawn/actors/actor.pb.ex
@@ -20,7 +20,7 @@ defmodule Eigr.Functions.Protocol.Actors.Kind do
           __unknown_fields__: []
         },
         %Google.Protobuf.EnumValueDescriptorProto{
-          name: "UNAMED",
+          name: "UNNAMED",
           number: 2,
           options: nil,
           __unknown_fields__: []
@@ -47,7 +47,7 @@ defmodule Eigr.Functions.Protocol.Actors.Kind do
 
   field(:UNKNOW_KIND, 0)
   field(:NAMED, 1)
-  field(:UNAMED, 2)
+  field(:UNNAMED, 2)
   field(:POOLED, 3)
   field(:PROXY, 4)
 end

--- a/priv/protos/eigr/functions/protocol/actors/actor.proto
+++ b/priv/protos/eigr/functions/protocol/actors/actor.proto
@@ -94,11 +94,11 @@ enum Kind {
     // NAMED actors are used to create children of this based actor at runtime
     NAMED = 1;
 
-    // UNAMED actors as the name suggests have only one real instance of themselves running 
+    // UNNAMED actors as the name suggests have only one real instance of themselves running 
     // during their entire lifecycle. That is, they are the opposite of the NAMED type Actors.
-    UNAMED = 2;
+    UNNAMED = 2;
     
-    // Pooled Actors are similar to Unamed actors, but unlike them, 
+    // Pooled Actors are similar to Unnamed actors, but unlike them, 
     // their identifying name will always be the one registered at the system initialization stage. 
     // The great advantage of Pooled actors is that they have multiple instances of themselves 
     // acting as a request service pool.
@@ -143,7 +143,7 @@ message ActorId {
     // Name of a ActorSystem
     string system = 2;
 
-    // When the Actor is of the Unamed type, 
+    // When the Actor is of the Unnamed type, 
     // the name of the parent Actor must be informed here.
     string parent = 3;
 }

--- a/priv/protos/eigr/functions/protocol/actors/protocol.proto
+++ b/priv/protos/eigr/functions/protocol/actors/protocol.proto
@@ -58,7 +58,7 @@
 //
 // Actors are usually created at the beginning of the SDK's communication flow with the Proxy by the registration step described above. 
 // However, some use cases require that Actors can be created ***on the fly***. 
-// In other words, Spawn is used to bring to life Actors previously registered as Unameds, giving them a name and thus creating a concrete instance 
+// In other words, Spawn is used to bring to life Actors previously registered as Unnameds, giving them a name and thus creating a concrete instance 
 // at runtime for that Actor. Actors created with the Spawn feature are generally used when you want to share a behavior while maintaining 
 // the isolation characteristics of the actors.
 // For these situations we have the Spawning flow described below. 

--- a/spawn_activators/activator_api/lib/activator_api/application.ex
+++ b/spawn_activators/activator_api/lib/activator_api/application.ex
@@ -53,7 +53,7 @@ defmodule ActivatorAPI.Application do
       #   system: "spawn-system",
       #   actor: "robert",
       #   action: "sum",
-      #   parent_actor: "unamed_actor",
+      #   parent_actor: "unnamed_actor",
       #   options: %{
       #     # valids are: "invoke", "spawn-invoke"
       #     invocation_type: "spawn-invoke",

--- a/spawn_activators/activator_simple/src/protocol_pb.rs
+++ b/spawn_activators/activator_simple/src/protocol_pb.rs
@@ -168,10 +168,10 @@ pub enum Kind {
     UnknowKind = 0,
     /// NAMED actors are used to create children of this based actor at runtime
     Named = 1,
-    /// UNAMED actors as the name suggests have only one real instance of themselves running 
+    /// UNNAMED actors as the name suggests have only one real instance of themselves running 
     /// during their entire lifecycle. That is, they are the opposite of the NAMED type Actors.
-    Unamed = 2,
-    /// Pooled Actors are similar to Unamed actors, but unlike them, 
+    Unnamed = 2,
+    /// Pooled Actors are similar to Unnamed actors, but unlike them, 
     /// their identifying name will always be the one registered at the system initialization stage. 
     /// The great advantage of Pooled actors is that they have multiple instances of themselves 
     /// acting as a request service pool.
@@ -195,7 +195,7 @@ impl Kind {
         match self {
             Kind::UnknowKind => "UNKNOW_KIND",
             Kind::Named => "NAMED",
-            Kind::Unamed => "UNAMED",
+            Kind::Unnamed => "UNNAMED",
             Kind::Pooled => "POOLED",
             Kind::Proxy => "PROXY",
         }
@@ -205,7 +205,7 @@ impl Kind {
         match value {
             "UNKNOW_KIND" => Some(Self::UnknowKind),
             "NAMED" => Some(Self::Named),
-            "UNAMED" => Some(Self::Unamed),
+            "UNNAMED" => Some(Self::Unnamed),
             "POOLED" => Some(Self::Pooled),
             "PROXY" => Some(Self::Proxy),
             _ => None,

--- a/spawn_sdk/spawn_sdk/Examples.cheatmd
+++ b/spawn_sdk/spawn_sdk/Examples.cheatmd
@@ -7,7 +7,7 @@
 defmodule SpawnSdkExample.Actors.MyActor do
   use SpawnSdk.Actor,
     name: "jose", # Default is Full Qualified Module name a.k.a __MODULE__
-    kind: :named, # Default is already :u«named. Valid are :named | :unamed | :pooled
+    kind: :named, # Default is already :u«named. Valid are :named | :unnamed | :pooled
     stateful: true, # Default is already true
     state_type: Io.Eigr.Spawn.Example.MyState,
     deactivate_timeout: 30_000,
@@ -53,14 +53,14 @@ SpawnSdk.invoke("joe", system: "spawn-system", action: "ping", scheduled_to: ~U[
   {:ok, :async}
 ```
 
-## Using Unamed Actors
+## Using Unnamed Actors
 
 ```elixir
-# Unamed.ex
-defmodule SpawnSdkExample.Actors.UnamedActor do
+# Unnamed.ex
+defmodule SpawnSdkExample.Actors.UnnamedActor do
   use SpawnSdk.Actor,
-    name: "unamed_actor",
-    kind: :unamed,
+    name: "unnamed_actor",
+    kind: :unnamed,
     state_type: Io.Eigr.Spawn.Example.MyState
 
   require Logger
@@ -81,8 +81,8 @@ defmodule SpawnSdkExample.Actors.UnamedActor do
   end
 end
 
-# Spawning Unamed actors
-SpawnSdk.spawn_actor("robert", system: "spawn-system", actor: "unamed_actor")
+# Spawning Unnamed actors
+SpawnSdk.spawn_actor("robert", system: "spawn-system", actor: "unnamed_actor")
   :ok
 
 #  Invoke Spawned Actors
@@ -90,7 +90,7 @@ SpawnSdk.invoke("robert", system: "spawn-system", action: "sum", payload: %Io.Ei
   {:ok, %Io.Eigr.Spawn.Example.MyBusinessMessage{value: 16}}
 
 #  Invoke Actors in a lazy way without having to spawn them before
-SpawnSdk.invoke("robert_lazy", ref: SpawnSdkExample.Actors.UnamedActor, system: "spawn-system", action: "sum", payload: %Io.Eigr.Spawn.Example.MyBusinessMessage{value: 1})
+SpawnSdk.invoke("robert_lazy", ref: SpawnSdkExample.Actors.UnnamedActor, system: "spawn-system", action: "sum", payload: %Io.Eigr.Spawn.Example.MyBusinessMessage{value: 1})
   {:ok, %Io.Eigr.Spawn.Example.MyBusinessMessage{value: 1}}  
 ```
 
@@ -150,9 +150,9 @@ end
 
 ```elixir
 # side_effect.ex
-defmodule SpawnSdkExample.Actors.UnamedActor do
+defmodule SpawnSdkExample.Actors.UnnamedActor do
   use SpawnSdk.Actor,
-    kind: :unamed,
+    kind: :unnamed,
     stateful: false,
     state_type: Io.Eigr.Spawn.Example.MyState
 
@@ -251,7 +251,7 @@ end
 # driver.ex
 defmodule Fleet.Actors.Driver do
   use SpawnSdk.Actor,
-    kind: :unamed,
+    kind: :unnamed,
     state_type: Fleet.Domain.Driver
 
   alias Fleet.Domain.{
@@ -285,7 +285,7 @@ end
 
 defmodule Fleet.Actors.FleetControllersActor do
   use SpawnSdk.Actor,
-    kind: :unamed,
+    kind: :unnamed,
     channels: [
       {"fleet.controllers.topic", "update_position_receive"}
     ] # or just ["fleet.controllers.topic"] and it will forward to a action called receive
@@ -319,7 +319,7 @@ defmodule SpawnSdkExample.Application do
         actors: [
           # your actors here
           SpawnSdkExample.Actors.MyActor,
-          SpawnSdkExample.Actors.UnamedActor,
+          SpawnSdkExample.Actors.UnnamedActor,
           SpawnSdkExample.Actors.ClockActor,
           SpawnSdkExample.Actors.PooledActor
         ]

--- a/spawn_sdk/spawn_sdk/README.md
+++ b/spawn_sdk/spawn_sdk/README.md
@@ -72,7 +72,7 @@ In this example we are creating an actor in a Named way, that is, it is a known 
 defmodule SpawnSdkExample.Actors.MyActor do
   use SpawnSdk.Actor,
     name: "jose", # Default is Full Qualified Module name a.k.a __MODULE__
-    kind: :named, # Default is already :named. Valid are :named | :unamed | :pooled
+    kind: :named, # Default is already :named. Valid are :named | :unnamed | :pooled
     stateful: true, # Default is already true
     state_type: Io.Eigr.Spawn.Example.MyState, # or :json if you don't care about protobuf types
     deactivate_timeout: 30_000,
@@ -109,15 +109,15 @@ Note Keep in mind that any Action that has the names present in the list below w
 
 Defaults inicialization Action names: "**init**", "**Init**", "**setup**", "**Setup**"
 
-## Unamed Actor
+## Unnamed Actor
 
-We can also create Unnamed Dynamic/Lazy actors, that is, despite having its unamed behavior defined at compile time, a Lazy actor will only have a concrete instance when it is associated with an identifier/name at runtime. Below follows the same previous actor being defined as Unamed.
+We can also create Unnamed Dynamic/Lazy actors, that is, despite having its unnamed behavior defined at compile time, a Lazy actor will only have a concrete instance when it is associated with an identifier/name at runtime. Below follows the same previous actor being defined as Unnamed.
 
 ```elixir
-defmodule SpawnSdkExample.Actors.UnamedActor do
+defmodule SpawnSdkExample.Actors.UnnamedActor do
   use SpawnSdk.Actor,
-    name: "unamed_actor",
-    kind: :unamed,
+    name: "unnamed_actor",
+    kind: :unnamed,
     state_type: Io.Eigr.Spawn.Example.MyState
 
   require Logger
@@ -137,9 +137,9 @@ defmodule SpawnSdkExample.Actors.UnamedActor do
 end
 ```
 
-Notice that the only thing that has changed is the the kind of actor, in this case the kind is set to :unamed.
+Notice that the only thing that has changed is the the kind of actor, in this case the kind is set to :unnamed.
 
-> **_NOTE:_** Can Elixir programmers think in terms of Named vs Unamed actors as more or less known at startup vs dynamically supervised/registered? That is, defining your actors directly in the supervision tree or using a Dynamic Supervisor for that.
+> **_NOTE:_** Can Elixir programmers think in terms of Named vs Unnamed actors as more or less known at startup vs dynamically supervised/registered? That is, defining your actors directly in the supervision tree or using a Dynamic Supervisor for that.
 
 ## Pooled Actors
 
@@ -242,9 +242,9 @@ end
 Actors can also emit side effects to other Actors as part of their response. See an example:
 
 ```elixir
-defmodule SpawnSdkExample.Actors.UnamedActor do
+defmodule SpawnSdkExample.Actors.UnnamedActor do
   use SpawnSdk.Actor,
-    kind: :unamed,
+    kind: :unnamed,
     stateful: false,
     state_type: Io.Eigr.Spawn.Example.MyState
 
@@ -364,7 +364,7 @@ Actors can also send messages to a group of actors at once as an action callback
 ```elixir
 defmodule Fleet.Actors.Driver do
   use SpawnSdk.Actor,
-    kind: :unamed,
+    kind: :unnamed,
     state_type: Fleet.Domain.Driver
 
   alias Fleet.Domain.{
@@ -398,7 +398,7 @@ end
 
 defmodule Fleet.Actors.FleetControllersActor do
   use SpawnSdk.Actor,
-    kind: :unamed,
+    kind: :unnamed,
     channels: [
       {"fleet.controllers.topic", "update_position_receive"}
     ] # or just ["fleet.controllers.topic"] and it will forward to a action called receive
@@ -575,7 +575,7 @@ defmodule SpawnSdkExample.Application do
         system: "spawn-system",
         actors: [
           SpawnSdkExample.Actors.MyActor,
-          SpawnSdkExample.Actors.UnamedActor,
+          SpawnSdkExample.Actors.UnnamedActor,
           SpawnSdkExample.Actors.ClockActor,
           SpawnSdkExample.Actors.PooledActor
         ]
@@ -637,14 +637,14 @@ SpawnSdk.invoke("joe", system: "spawn-system", action: "get")
 Spawning Actors:
 
 ```elixir
-iex> SpawnSdk.spawn_actor("robert", system: "spawn-system", actor: "unamed_actor")
+iex> SpawnSdk.spawn_actor("robert", system: "spawn-system", actor: "unnamed_actor")
 :ok
 ```
 
 You can also create Actors so that they are initialized from a certain revision number, that is, initialize actors from a specific point in time.
 
 ```elixir
-iex> SpawnSdk.spawn_actor("robert", system: "spawn-system", actor: "unamed_actor", revision: 2)
+iex> SpawnSdk.spawn_actor("robert", system: "spawn-system", actor: "unnamed_actor", revision: 2)
 :ok
 ```
 
@@ -660,7 +660,7 @@ iex> SpawnSdk.invoke("robert", system: "spawn-system", action: "sum", payload: %
 Invoke Actors in a lazy way without having to spawn them before:
 
 ```elixir
-iex> SpawnSdk.invoke("robert_lazy", ref: SpawnSdkExample.Actors.UnamedActor, system: "spawn-system", action: "sum", payload: %Io.Eigr.Spawn.Example.MyBusinessMessage{value: 1})
+iex> SpawnSdk.invoke("robert_lazy", ref: SpawnSdkExample.Actors.UnnamedActor, system: "spawn-system", action: "sum", payload: %Io.Eigr.Spawn.Example.MyBusinessMessage{value: 1})
 {:ok, %Io.Eigr.Spawn.Example.MyBusinessMessage{value: 1}}
 ```
 

--- a/spawn_sdk/spawn_sdk/lib/actor.ex
+++ b/spawn_sdk/spawn_sdk/lib/actor.ex
@@ -115,7 +115,7 @@ defmodule SpawnSdk.Actor do
   Example:
 
   ```
-  iex(spawn_a@127.0.0.1)1> SpawnSdk.Actor.spawn("spawn-system", "joe", "unamed_actor")
+  iex(spawn_a@127.0.0.1)1> SpawnSdk.Actor.spawn("spawn-system", "joe", "unnamed_actor")
   %SpawnSdk.ActorRef{system: "spawn-system", name: "joe", opts: []}
   ```
 
@@ -126,7 +126,7 @@ defmodule SpawnSdk.Actor do
 
   my_data = %MyData{value: 1}
 
-  Actor.spawn("spawn-system", "joe", "unamed_actor")
+  Actor.spawn("spawn-system", "joe", "unnamed_actor")
   |> Actor.invoke(action: "sum", data: my_data)
   ```
   """

--- a/spawn_sdk/spawn_sdk/lib/flow.ex
+++ b/spawn_sdk/spawn_sdk/lib/flow.ex
@@ -37,7 +37,7 @@ defmodule SpawnSdk.Flow do
 
     defmodule Fleet.Actors.FleetControllersActor do
       use SpawnSdk.Actor,
-        kind: :unamed,
+        kind: :unnamed,
         channels: [
           {"fleet.controllers.topic", "update_position_receive"}
         ] # or just ["fleet.controllers.topic"] and it will forward to a action called receive

--- a/spawn_sdk/spawn_sdk/lib/spawn_sdk.ex
+++ b/spawn_sdk/spawn_sdk/lib/spawn_sdk.ex
@@ -51,7 +51,7 @@ defmodule SpawnSdk do
   ```elixir
   iex> SpawnSdk.invoke(
     "actor_name",
-    ref: SpawnSdkExample.Actors.UnamedActor,
+    ref: SpawnSdkExample.Actors.UnnamedActor,
     system: "spawn-system",
     action: "sum", # "sum" or :sum
     payload: %Io.Eigr.Spawn.Example.MyBusinessMessage{value: 5}
@@ -66,9 +66,9 @@ defmodule SpawnSdk do
   defdelegate invoke(actor_name, invoke_opts), to: SpawnSdk.System.SpawnSystem
 
   @doc """
-  Spawns a Unamed actor
+  Spawns a Unnamed actor
 
-  A Unamed actor means that you can spawn dynamically the same actor for multiple different names.
+  A Unnamed actor means that you can spawn dynamically the same actor for multiple different names.
   It is analog to `DynamicSupervisor`
 
   ## Opts
@@ -82,7 +82,7 @@ defmodule SpawnSdk do
   iex> SpawnSdk.spawn_actor(
     "actor_name",
     system: "spawn-system",
-    actor: SpawnSdkExample.Actors.UnamedActor
+    actor: SpawnSdkExample.Actors.UnnamedActor
   )
   ```
   """

--- a/spawn_sdk/spawn_sdk/lib/system/spawn_system.ex
+++ b/spawn_sdk/spawn_sdk/lib/system/spawn_system.ex
@@ -556,9 +556,11 @@ defmodule SpawnSdk.System.SpawnSystem do
     end)
   end
 
-  def decode_kind(:abstract), do: :UNAMED
-  def decode_kind(:ABSTRACT), do: :UNAMED
-  def decode_kind(:unamed), do: :UNAMED
+  def decode_kind(:abstract), do: :UNNAMED
+  def decode_kind(:ABSTRACT), do: :UNNAMED
+  def decode_kind(:unnamed), do: :UNNAMED
+  def decode_kind(:unamed), do: :UNNAMED
+  def decode_kind(:UNAMED), do: :UNNAMED
   def decode_kind(:SINGLETON), do: :NAMED
   def decode_kind(:singleton), do: :NAMED
   def decode_kind(:named), do: :NAMED

--- a/spawn_sdk/spawn_sdk/test/actor/actor_test.exs
+++ b/spawn_sdk/spawn_sdk/test/actor/actor_test.exs
@@ -6,7 +6,7 @@ defmodule Actor.ActorTest do
   defmodule Actor.MyActor do
     use SpawnSdk.Actor,
       name: "my_actor_ref",
-      kind: :unamed,
+      kind: :unnamed,
       stateful: false,
       state_type: Eigr.Spawn.Actor.MyState,
       tags: [{"foo", "none"}, {"bar", "unchanged"}]
@@ -219,7 +219,7 @@ defmodule Actor.ActorTest do
     end
 
     test "get defaults" do
-      assert :UNAMED == Actor.MyActor.__meta__(:kind)
+      assert :UNNAMED == Actor.MyActor.__meta__(:kind)
       assert false == Actor.MyActor.__meta__(:stateful)
       assert 10_000 == Actor.MyActor.__meta__(:deactivate_timeout)
       assert 2_000 == Actor.MyActor.__meta__(:snapshot_timeout)

--- a/spawn_sdk/spawn_sdk_example/benchmark.exs
+++ b/spawn_sdk/spawn_sdk_example/benchmark.exs
@@ -19,7 +19,7 @@ Benchee.run(
     "Async Non Parallel Actor - Update State" => fn ->
       async_invoke_update_state()
     end,
-    # "Non Parallel Unamed Spawn and Invoke Actor  - Update State" => fn ->
+    # "Non Parallel Unnamed Spawn and Invoke Actor  - Update State" => fn ->
     #   spawn_and_invoke()
     # end
     # "Non Parallel Stateless Pooled Actor                    - Call Action " => fn ->
@@ -58,7 +58,7 @@ Benchee.run(
 #     "Async Non Parallel Actor - Update State" => fn ->
 #       async_invoke_update_state()
 #     end,
-#     # "Non Parallel Unamed Spawn and Invoke Actor  - Update State" => fn ->
+#     # "Non Parallel Unnamed Spawn and Invoke Actor  - Update State" => fn ->
 #     #   spawn_and_invoke()
 #     # end
 #     # "Non Parallel Stateless Pooled Actor                    - Call Action " => fn ->

--- a/spawn_sdk/spawn_sdk_example/lib/spawn_sdk_example.ex
+++ b/spawn_sdk/spawn_sdk_example/lib/spawn_sdk_example.ex
@@ -5,7 +5,7 @@ defmodule SpawnSdkExample do
   require Logger
 
   alias Io.Eigr.Spawn.Example.MyBusinessMessage
-  alias SpawnSdkExample.Actors.UnamedActor
+  alias SpawnSdkExample.Actors.UnnamedActor
 
   def invoke_update_state() do
     try do
@@ -46,7 +46,7 @@ defmodule SpawnSdkExample do
   def spawn_and_invoke() do
     try do
       SpawnSdk.invoke("robert_lazy",
-        ref: UnamedActor,
+        ref: UnnamedActor,
         system: "spawn-system",
         action: "sum",
         payload: %MyBusinessMessage{value: 1}

--- a/spawn_sdk/spawn_sdk_example/lib/spawn_sdk_example/actors/unamed_actor.ex
+++ b/spawn_sdk/spawn_sdk_example/lib/spawn_sdk_example/actors/unamed_actor.ex
@@ -1,7 +1,7 @@
-defmodule SpawnSdkExample.Actors.UnamedActor do
+defmodule SpawnSdkExample.Actors.UnnamedActor do
   use SpawnSdk.Actor,
-    name: "unamed_actor",
-    kind: :unamed,
+    name: "unnamed_actor",
+    kind: :unnamed,
     deactivate_timeout: 60_000,
     state_type: Io.Eigr.Spawn.Example.MyState
 
@@ -10,7 +10,7 @@ defmodule SpawnSdkExample.Actors.UnamedActor do
   alias Io.Eigr.Spawn.Example.{MyState, MyBusinessMessage}
 
   defact sum(%MyBusinessMessage{value: value} = data, %Context{state: state} = ctx) do
-    Logger.info("[Unamed Actor] Received Request: #{inspect(data)}. Context: #{inspect(ctx)}")
+    Logger.info("[Unnamed Actor] Received Request: #{inspect(data)}. Context: #{inspect(ctx)}")
 
     new_value =
       if is_nil(state) do

--- a/spawn_sdk/spawn_sdk_example/lib/spawn_sdk_example/application.ex
+++ b/spawn_sdk/spawn_sdk_example/lib/spawn_sdk_example/application.ex
@@ -12,7 +12,7 @@ defmodule SpawnSdkExample.Application do
           SpawnSdkExample.Actors.JoeActor,
           SpawnSdkExample.Actors.JsonActor,
           # SpawnSdkExample.Actors.ClockActor,
-          SpawnSdkExample.Actors.UnamedActor,
+          SpawnSdkExample.Actors.UnnamedActor,
           SpawnSdkExample.Actors.PubSubActor
           # Pooled Actors have been removed and will be restructured in the future
           # SpawnSdkExample.Actors.PooledActor


### PR DESCRIPTION
Our actors define a kind unamed, this fixes the typo to Unnamed properly.

Relates with:

https://github.com/eigr/spawn-node-sdk/pull/5